### PR TITLE
KTLO Run CI on any PR branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: "PR checks"
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,6 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Ensures PR checks run on any PRs, not just those to `main`.