### PR TITLE
Add final answers to state

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -81,6 +81,13 @@ export class Network {
   }
 
   /**
+   * the answer getter returns the final answer from the agent loop, if set.
+   */
+  get answer(): unknown {
+    return this.state.answer;
+  }
+
+  /**
    * addAgent adds a new agent to the network.
    */
   addAgent(agent: Agent) {
@@ -120,6 +127,7 @@ export class Network {
 
     while (
       this._stack.length > 0 &&
+      this.state.answer === undefined &&
       (this.maxIter === 0 || this._counter < this.maxIter)
     ) {
       // XXX: It would be possible to parallel call these agents here by

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,12 +15,14 @@ export interface TextMessage {
   type: "text";
   text: string;
 }
+
 export interface ToolMessage {
   type: "tool";
   id: string;
   name: string;
   input: Record<string, unknown>;
 }
+
 export interface ToolResult {
   type: "tool_result";
   id: string;
@@ -50,6 +52,11 @@ export class State {
 
   private _history: InferenceResult[];
 
+  /**
+   * answer stores the final answer.
+   */
+  private _answer: unknown;
+
   constructor() {
     this._history = [];
     this._kv = new Map();
@@ -70,6 +77,24 @@ export class State {
         return this._kv.has(key);
       },
     };
+  }
+
+  /**
+   * setting an answer signals that we have a final answer.  The presence
+   * of an answer stops networks from running its router loop.
+   *
+   * Note that setting an answer must only be done once we have a final answer
+   * from the agentic loop.  It should not be used for interim state.
+   */
+  set answer(answer: unknown) {
+    this._answer = answer;
+  }
+
+  /**
+   * the answer getter returns the final answer from the agent loop, if set.
+   */
+  get answer(): unknown {
+    return this._answer;
   }
 
   /**


### PR DESCRIPTION
Setting a final answer in state (eg. in a router, or in a lifecycle) forces the network to terminate.

This lets us have a single, unified way to extract results from an agentic loop.

Note that the final answer can be of any shape, and is currently typed as `unknown`.