### PR TITLE
Fix network -> agent tate in run

### DIFF
--- a/examples/swebench/inngest.ts
+++ b/examples/swebench/inngest.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import fs from "fs";
 import { EventSchemas, Inngest } from "inngest";
 import { z } from "zod";
+import { State } from "@inngest/agent-kit";
 import { codeWritingNetwork } from "./networks/codeWritingNetwork";
 
 export const inngest = new Inngest({
@@ -49,8 +50,12 @@ export const fn = inngest.createFunction(
       execSync(`cd ${dir} && git reset --hard FETCH_HEAD`);
     });
 
+    // Create new state and store the repo in KV for access via tools.
+    const state = new State();
+    state.kv.set("repo", event.data.repo);
+
     await codeWritingNetwork.run(event.data.problem_statement, {
-      state: { repo: event.data.repo },
+      state,
     });
   }
 );

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,5 @@
 import { type AiAdapter } from "inngest";
 import { createAgenticModelFromAiAdapter, type AgenticModel } from "./model";
-import { type Network } from "./network";
 import { NetworkRun } from "./networkRun";
 import {
   InferenceResult,
@@ -119,8 +118,8 @@ export class Agent {
     const p = createAgenticModelFromAiAdapter(rawModel);
 
     // input state always overrides the network state.
-    const s = state || network?.defaultState?.clone();
-    const run = network && new NetworkRun(network, s || new State());
+    const s = state || network?.state?.clone() || new State();
+    const run = network && new NetworkRun(network, s);
 
     let history = s ? s.format() : [];
     let prompt = await this.agentPrompt(input, run);
@@ -361,7 +360,7 @@ export namespace Agent {
 
   export interface RunOptions {
     model?: AiAdapter.Any;
-    network?: Network;
+    network?: NetworkRun;
     /**
      * State allows you to pass custom state into a single agent run call.  This should only
      * be provided if you are running agents outside of a network.  Networks automatically

--- a/src/state.ts
+++ b/src/state.ts
@@ -68,6 +68,7 @@ export class State {
     get: <T = any>(key: string) => T | undefined;
     delete: (key: string) => boolean;
     has: (key: string) => boolean;
+    all: () => Record<string, unknown>;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,6 +96,9 @@ export class State {
       },
       has: (key: string) => {
         return this._kv.has(key);
+      },
+      all: () => {
+        return Object.fromEntries(this._kv);
       },
     };
   }


### PR DESCRIPTION
For some reason, we were not using the actual run state when calling agent.run in networks.  This is via a large refactor.