### PR TITLE
Use node:path in tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,11 @@
   },
   "lint-staged": {
     "*.{j,t}s": "eslint --cache --fix"
+  },
+  "prettier": {
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "trailingComma": "es5"
   }
 }


### PR DESCRIPTION
* Minor refactor to use `path.join` - the recommended way to join file paths
* Add local prettier config matching `inngest-js` to for auto-formatting rules (ensure editors don't change double to single quotes, etc.)