### PR TITLE
Add basic server

### DIFF
--- a/.changeset/pretty-planes-do.md
+++ b/.changeset/pretty-planes-do.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": minor
+---
+
+Add basic AgentKit server to serve agents and networks as Inngest functions for easy testing

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "express": "^4.21.1",
-    "inngest": "^3.28.0",
+    "inngest": "^3.29.0",
     "openai-zod-to-json-schema": "^1.0.3",
     "zod": "^3.23.8"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "require": "./dist/index.js",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "require": "./dist/server.js",
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4.21.1
         version: 4.21.1
       inngest:
-        specifier: ^3.28.0
-        version: 3.28.0(express@4.21.1)(typescript@5.7.2)
+        specifier: ^3.29.0
+        version: 3.29.0(express@4.21.1)(typescript@5.7.2)
       openai-zod-to-json-schema:
         specifier: ^1.0.3
         version: 1.0.3(zod@3.23.8)
@@ -866,8 +866,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  inngest@3.28.0:
-    resolution: {integrity: sha512-7myzcPkX+A0PakUMwczIdDqt5lpHEgVqeK0N8IUcONjajlt/g1sk+yjZ88ER8SxoJWCFFoAV04NJdZN9ka1N1A==}
+  inngest@3.29.0:
+    resolution: {integrity: sha512-TQV9ce8nxNvj1nzOzWb197UHXHuXG3YHAkoSe0U5oqTAE7vs0a4HxQAzTivovsS9Z32f6FVx+m78Fov8sV0lQA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
@@ -2477,7 +2477,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inngest@3.28.0(express@4.21.1)(typescript@5.7.2):
+  inngest@3.29.0(express@4.21.1)(typescript@5.7.2):
     dependencies:
       '@types/debug': 4.1.12
       canonicalize: 1.0.8

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./agent";
 export * from "./model";
 export * from "./network";
 export * from "./networkRun";
+export * from "./server";
 export * from "./state";
 export * from "./types";
 export * from "./util";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ export * from "./agent";
 export * from "./model";
 export * from "./network";
 export * from "./networkRun";
-export * from "./server";
 export * from "./state";
 export * from "./types";
 export * from "./util";

--- a/src/network.ts
+++ b/src/network.ts
@@ -24,6 +24,8 @@ export class Network {
    */
   name: string;
 
+  description?: string;
+
   /**
    * agents are all publicly available agents in the netwrok
    */
@@ -62,6 +64,7 @@ export class Network {
 
   constructor({
     name,
+    description,
     agents,
     defaultModel,
     maxIter,
@@ -69,6 +72,7 @@ export class Network {
     defaultRouter,
   }: Network.Constructor) {
     this.name = name;
+    this.description = description;
     this.agents = new Map();
     this._agents = new Map();
     this.defaultModel = defaultModel;
@@ -242,6 +246,7 @@ Follow the set of instructions:
 export namespace Network {
   export type Constructor = {
     name: string;
+    description?: string;
     agents: Agent[];
     defaultModel?: AiAdapter.Any;
     maxIter?: number;

--- a/src/network.ts
+++ b/src/network.ts
@@ -20,6 +20,11 @@ export const createNetwork = (opts: Network.Constructor) => new Network(opts);
  */
 export class Network {
   /**
+   * The name for the system of agents
+   */
+  name?: string;
+
+  /**
    * agents are all publicly available agents in the netwrok
    */
   agents: Map<string, Agent>;
@@ -56,12 +61,14 @@ export class Network {
   protected _agents: Map<string, Agent>;
 
   constructor({
+    name,
     agents,
     defaultModel,
     maxIter,
     defaultState,
     defaultRouter,
   }: Network.Constructor) {
+    this.name = name;
     this.agents = new Map();
     this._agents = new Map();
     this.defaultModel = defaultModel;
@@ -82,7 +89,7 @@ export class Network {
   }
 
   async availableAgents(
-    networkRun: NetworkRun = new NetworkRun(this, new State()),
+    networkRun: NetworkRun = new NetworkRun(this, new State())
   ): Promise<Agent[]> {
     const available: Agent[] = [];
     const all = Array.from(this.agents.values());
@@ -169,7 +176,7 @@ export const getDefaultRoutingAgent = () => {
         handler: ({ name }, { network }) => {
           if (!network) {
             throw new Error(
-              "The routing agent can only be used within a network of agents",
+              "The routing agent can only be used within a network of agents"
             );
           }
 
@@ -180,7 +187,7 @@ export const getDefaultRoutingAgent = () => {
           const agent = network.agents.get(name);
           if (agent === undefined) {
             throw new Error(
-              `The routing agent requested an agent that doesn't exist: ${name}`,
+              `The routing agent requested an agent that doesn't exist: ${name}`
             );
           }
 
@@ -196,7 +203,7 @@ export const getDefaultRoutingAgent = () => {
     system: async ({ network }): Promise<string> => {
       if (!network) {
         throw new Error(
-          "The routing agent can only be used within a network of agents",
+          "The routing agent can only be used within a network of agents"
         );
       }
 
@@ -207,15 +214,15 @@ export const getDefaultRoutingAgent = () => {
 The following agents are available:
 <agents>
   ${agents
-    .map((a) => {
-      return `
+          .map((a) => {
+            return `
     <agent>
       <name>${a.name}</name>
       <description>${a.description}</description>
       <tools>${JSON.stringify(Array.from(a.tools.values()))}</tools>
     </agent>`;
-    })
-    .join("\n")}
+          })
+          .join("\n")}
 </agents>
 
 Follow the set of instructions:
@@ -234,6 +241,7 @@ Follow the set of instructions:
 
 export namespace Network {
   export type Constructor = {
+    name?: string;
     agents: Agent[];
     defaultModel?: AiAdapter.Any;
     maxIter?: number;
@@ -270,7 +278,7 @@ export namespace Network {
      *
      */
     export type FnRouter = (
-      args: Args,
+      args: Args
     ) => MaybePromise<RoutingAgent | Agent | Agent[] | undefined>;
 
     export interface Args {

--- a/src/network.ts
+++ b/src/network.ts
@@ -22,7 +22,7 @@ export class Network {
   /**
    * The name for the system of agents
    */
-  name?: string;
+  name: string;
 
   /**
    * agents are all publicly available agents in the netwrok
@@ -214,15 +214,15 @@ export const getDefaultRoutingAgent = () => {
 The following agents are available:
 <agents>
   ${agents
-          .map((a) => {
-            return `
+    .map((a) => {
+      return `
     <agent>
       <name>${a.name}</name>
       <description>${a.description}</description>
       <tools>${JSON.stringify(Array.from(a.tools.values()))}</tools>
     </agent>`;
-          })
-          .join("\n")}
+    })
+    .join("\n")}
 </agents>
 
 Follow the set of instructions:
@@ -241,7 +241,7 @@ Follow the set of instructions:
 
 export namespace Network {
   export type Constructor = {
-    name?: string;
+    name: string;
     agents: Agent[];
     defaultModel?: AiAdapter.Any;
     maxIter?: number;

--- a/src/networkRun.ts
+++ b/src/networkRun.ts
@@ -7,6 +7,8 @@ export class NetworkRun extends Network {
 
   constructor(network: Network, state: State) {
     super({
+      name: network.name,
+      description: network.description,
       agents: Array.from(network.agents.values()),
       defaultModel: network.defaultModel,
       defaultState: network.defaultState,
@@ -43,7 +45,7 @@ export class NetworkRun extends Network {
     // off of the network.
     const next = await this.getNextAgents(
       input,
-      overrides?.router || this.defaultRouter,
+      overrides?.router || this.defaultRouter
     );
     if (!next) {
       // TODO: If call count is 0, error.
@@ -92,7 +94,7 @@ export class NetworkRun extends Network {
       // custom code.
       const next = await this.getNextAgents(
         input,
-        overrides?.router || this.defaultRouter,
+        overrides?.router || this.defaultRouter
       );
       for (const a of next || []) {
         this.schedule(a.name);
@@ -104,7 +106,7 @@ export class NetworkRun extends Network {
 
   private async getNextAgents(
     input: string,
-    router?: Network.Router,
+    router?: Network.Router
   ): Promise<Agent[] | undefined> {
     // A router may do one of two things:
     //
@@ -114,7 +116,7 @@ export class NetworkRun extends Network {
     // It can do this by using code, or by calling routing agents directly.
     if (!router && !this.defaultModel) {
       throw new Error(
-        "No router or model defined in network.  You must pass a router or a default model to use the built-in agentic router.",
+        "No router or model defined in network.  You must pass a router or a default model to use the built-in agentic router."
       );
     }
     if (!router) {
@@ -162,7 +164,7 @@ export class NetworkRun extends Network {
 
   private async getNextAgentsViaRoutingAgent(
     routingAgent: RoutingAgent,
-    input: string,
+    input: string
   ): Promise<Agent[] | undefined> {
     const result = await routingAgent.run(input, {
       network: this,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,84 @@
+import { Inngest, type InngestFunction } from "inngest";
+import { createServer as createInngestServer } from "inngest/node";
+
+import { type Network } from "./network";
+import { type Agent } from "./agent";
+
+function slugify(str: string): string {
+  return str
+    .replace(/^\s+|\s+$/g, "") // trim leading/trailing white space
+    .toLowerCase() // convert string to lowercase
+    .replace(/[^a-z0-9 -]/g, "") // remove any non-alphanumeric characters
+    .replace(/\s+/g, "-") // replace spaces with hyphens
+    .replace(/-+/g, "-"); // remove consecutive hyphens
+}
+
+/**
+ * Create a server to serve Agents and Networks as Inngest functions
+ *
+ * @example
+ * ```ts
+ * import { createServer, createAgent, createNetwork } from "@inngest/agent-kit";
+ *
+ * const myAgent = createAgent(...);
+ * const myNetwork = createNetwork(...);
+ * const server = createServer({
+ *   agents: [myAgent],
+ *   networks: [myNetworks],
+ * });
+ * server.listen(3000)
+ * ```
+ *
+ * @public
+ */
+export const createServer = ({
+  networks = [],
+  agents = [],
+}: {
+  networks?: Network[];
+  agents?: Agent[];
+}) => {
+  const appId = "agent-kit";
+  const inngest = new Inngest({
+    id: appId,
+  });
+  const functions: { [keyof: string]: InngestFunction.Any } = {};
+
+  for (const agent of agents) {
+    const slug = slugify(agent.name);
+    const id = `agent-${slug}`;
+    functions[id] = inngest.createFunction(
+      { id, name: agent.name },
+      { event: `${appId}/${id}` },
+      async ({ event }) => {
+        // eslint-disable-next-line
+        return agent.run(event.data.input);
+      }
+    );
+  }
+  let networkIdx = 0;
+  for (const network of networks) {
+    networkIdx++;
+    const name = network.name ?? `My network #${networkIdx}`;
+    if (!network.name) {
+      console.warn(
+        `Network missing 'name' option. Created generic name: ${name}`
+      );
+    }
+    const slug = slugify(name);
+    const id = `network-${slug}`;
+    functions[id] = inngest.createFunction(
+      { id, name },
+      { event: `${appId}/${id}` },
+      async ({ event }) => {
+        // eslint-disable-next-line
+        return network.run(event.data.input);
+      }
+    );
+  }
+
+  return createInngestServer({
+    client: inngest,
+    functions: Object.values(functions),
+  });
+};


### PR DESCRIPTION
Extend the vanilla Node.js server (https://github.com/inngest/inngest-js/pull/788) to enable a user to serve AgentKit networks and agents as Inngest functions without having to learn Inngest.