### PR TITLE
Export models for ease of discovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Base
 export * from "./agent";
 export * from "./model";
+export * from "./models";
 export * from "./network";
 export * from "./networkRun";
 export * from "./state";

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,1 @@
+export { openai, anthropic, gemini } from "inngest";


### PR DESCRIPTION
This exports the models provided by the `inngest` package currently. This makes everything feel like it's centralized and also allows us to adapt this over time and potentially move these models to a neutral `@inngest/ai` package to eventually remove dependencies.

```ts
import { openai, anthropic, gemini } from "@inngest/agent-kit";

// currently it's this:
import { openai, anthropic, gemini } from "inngest";
```