### PR TITLE
fix(tools): better support for strict mode + option to opt-out

### DIFF
--- a/.changeset/yellow-olives-give.md
+++ b/.changeset/yellow-olives-give.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+fix(tools): better support for strict mode + option to opt-out

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -1,8 +1,8 @@
 ---
 title: Tools
 description: Extending the functionality of Agents for structured output or performing tasks.
-icon: 'screwdriver-wrench'
-iconType: 'light'
+icon: "screwdriver-wrench"
+iconType: "light"
 ---
 
 Tools are functions that extend the capabilities of an [Agent](/concepts/agents). Tools have two core uses:
@@ -40,6 +40,29 @@ const listChargesTool = createTool({
 ```
 
 Writing quality `name` and `description` parameters help the model determine when the particular Tool should be called.
+
+### Optional parameters
+
+Optional parameters should be defined using `.nullable()` (not `.optional()`):
+
+```ts {7-10}
+const listChargesTool = createTool({
+  name: 'list_charges',
+  description:
+    "Returns all of a user's charges. Call this whenever you need to find one or more charges between a date range.",
+  parameters: z.object({
+    userId: z.string(),
+    created: z.object({
+      gte: z.string().date(),
+      lte: z.string().date(),
+    }).nullable(),
+  }),
+  handler: async ({ userId, created }, { network, agent, step }) => {
+    // output is strongly typed to match the parameter type.
+    return [{...}]
+  },
+});
+```
 
 ## Examples
 

--- a/docs/reference/create-tool.mdx
+++ b/docs/reference/create-tool.mdx
@@ -50,6 +50,10 @@ const tool = createTool({
   The function that executes when the tool is called. It receives the validated parameters as its first argument and a context object as its second argument.
 </ParamField>
 
+<ParamField path="strict" type="boolean" default={true}>
+  Option to disable strict validation of the tool parameters.
+</ParamField>
+
 <ParamField path="lifecycle" type="Lifecycle">
   Lifecycle hooks that can intercept and modify inputs and outputs throughout the stages of tool execution.
 </ParamField>

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -58,7 +58,7 @@
     "@modelcontextprotocol/sdk": "^1.1.1",
     "eventsource": "^3.0.2",
     "express": "^4.21.1",
-    "openai-zod-to-json-schema": "^1.0.3",
+    "zod-to-json-schema": "^3.24.3",
     "zod": "^3.23.8"
   },
   "packageManager": "pnpm@9.14.2",

--- a/packages/agent-kit/pnpm-lock.yaml
+++ b/packages/agent-kit/pnpm-lock.yaml
@@ -26,12 +26,12 @@ importers:
       inngest:
         specifier: 3.32.5
         version: 3.32.5(express@4.21.2)(typescript@5.7.3)
-      openai-zod-to-json-schema:
-        specifier: ^1.0.3
-        version: 1.0.3(zod@3.24.1)
       zod:
         specifier: ^3.23.8
         version: 3.24.1
+      zod-to-json-schema:
+        specifier: ^3.24.3
+        version: 3.24.3(zod@3.24.1)
     devDependencies:
       '@types/express':
         specifier: ^5.0.0
@@ -1498,12 +1498,6 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
-  openai-zod-to-json-schema@1.0.3:
-    resolution: {integrity: sha512-CFU+KtOmX1dk2nPCZcGYgbrI3YLJJgMSehx1mLbH1A2fsRmZevHzMau6vFIhtkCpHWkGQ3ossA4a0OzVHlGrkw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2013,8 +2007,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-to-json-schema@3.24.1:
-    resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
+  zod-to-json-schema@3.24.3:
+    resolution: {integrity: sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==}
     peerDependencies:
       zod: ^3.24.1
 
@@ -2283,7 +2277,7 @@ snapshots:
       eventsource: 3.0.5
       raw-body: 3.0.0
       zod: 3.24.1
-      zod-to-json-schema: 3.24.1(zod@3.24.1)
+      zod-to-json-schema: 3.24.3(zod@3.24.1)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3318,10 +3312,6 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
-  openai-zod-to-json-schema@1.0.3(zod@3.24.1):
-    dependencies:
-      zod: 3.24.1
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3851,7 +3841,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.24.1(zod@3.24.1):
+  zod-to-json-schema@3.24.3(zod@3.24.1):
     dependencies:
       zod: 3.24.1
 

--- a/packages/agent-kit/src/adapters/anthropic.ts
+++ b/packages/agent-kit/src/adapters/anthropic.ts
@@ -8,7 +8,7 @@ import {
   type Anthropic,
   type AnthropicAiAdapter,
 } from "@inngest/ai";
-import { zodToJsonSchema } from "openai-zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { z } from "zod";
 import { type AgenticModel } from "../model";
 import { type Message, type TextMessage } from "../state";

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -7,7 +7,7 @@
  */
 import { type AiAdapter, type Gemini } from "@inngest/ai";
 import { z, type ZodSchema } from "zod";
-import { zodToJsonSchema } from "openai-zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 import { type AgenticModel } from "../model";
 import type { Tool } from "../tool";

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -5,7 +5,7 @@
  */
 
 import { type AiAdapter, type OpenAi } from "@inngest/ai";
-import { zodToJsonSchema } from "openai-zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { type AgenticModel } from "../model";
 import {
   type Message,
@@ -66,7 +66,10 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
     // OpenAI o3 models have several issues with tool calling.
     //  one of them is not supporting the `parallel_tool_calls` parameter
     //  https://community.openai.com/t/o3-mini-api-with-tools-only-ever-returns-1-tool-no-matter-prompt/1112390/6
-    if (!model.options.model?.includes("o3") && !model.options.model?.includes("o1")) {
+    if (
+      !model.options.model?.includes("o3") &&
+      !model.options.model?.includes("o1")
+    ) {
       // it is recommended to disable parallel tool calls with structured output
       // https://platform.openai.com/docs/guides/function-calling#parallel-function-calling-and-structured-outputs
       request.parallel_tool_calls = false;
@@ -77,8 +80,10 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
         function: {
           name: t.name,
           description: t.description,
-          parameters: t.parameters && zodToJsonSchema(t.parameters),
-          strict: Boolean(t.parameters), // strict mode is only supported with parameters
+          parameters:
+            t.parameters && zodToJsonSchema(t.parameters, { target: "openAi" }),
+          strict:
+            typeof t.strict !== "undefined" ? t.strict : Boolean(t.parameters), // strict mode is only supported with parameters
         },
       };
     });

--- a/packages/agent-kit/src/tool.ts
+++ b/packages/agent-kit/src/tool.ts
@@ -16,6 +16,8 @@ export type Tool<TInput extends Tool.Input> = {
     tool: MCP.Tool;
   };
 
+  strict?: boolean;
+
   // TODO: Handler input types based off of JSON above.
   //
   // Handlers get their input arguments from inference calls, and can also


### PR DESCRIPTION
As stated in OpenAI docs, in strict mode, [all tool parameters must be required](https://platform.openai.com/docs/guides/structured-outputs?context=with_parse#all-fields-must-be-required).
However, it is possible to emulate "nullable" field with a JSONSchema union type which is not supported by standard libraries.
OpenAI has a vendored version of `zod-to-json-schema` to support this.
Good news is that `zod-to-json-schema` backported OpenAI vendored version in their lib in last December 2024.