### PR TITLE
fix(mcp): emit valid tool name from MCP tools

### DIFF
--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -427,7 +427,7 @@ export class Agent {
         ListToolsResultSchema
       );
       results.tools.forEach((t) => {
-        const name = `${server.name}: ${t.name}`;
+        const name = `${server.name}-${t.name}`;
 
         let zschema: undefined | ZodType;
         try {


### PR DESCRIPTION
Tool name should not contain space:
 ```
    {"type":"error","error":{"type":"invalid_request_error","message":"tools.0.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,64}$'"}}
    ```