### PR TITLE
Optimize parallelism in `createServer()`

### DIFF
--- a/.changeset/hot-months-sit.md
+++ b/.changeset/hot-months-sit.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Optimize parallelism in `createServer()`, removing risk of parallel indexing

--- a/packages/agent-kit/src/server.ts
+++ b/packages/agent-kit/src/server.ts
@@ -51,7 +51,7 @@ export const createServer = ({
     const id = `agent-${slug}`;
 
     functions[id] = inngest.createFunction(
-      { id, name: agent.name },
+      { id, name: agent.name, optimizeParallelism: true },
       { event: `${inngest.id}/${id}` },
       async ({ event }) => {
         // eslint-disable-next-line
@@ -65,7 +65,7 @@ export const createServer = ({
     const id = `network-${slug}`;
 
     functions[id] = inngest.createFunction(
-      { id, name: network.name },
+      { id, name: network.name, optimizeParallelism: true },
       { event: `${inngest.id}/${id}` },
       async ({ event }) => {
         // eslint-disable-next-line


### PR DESCRIPTION
## Summary

Uses `optimizeParallelism: true` when running `createServer()`, circumventing warnings of parallel indexing.

## Related

- Uses inngest/inngest-js#862