### PR TITLE
bug: multiple mcp server instances get created

### DIFF
--- a/packages/agent-kit/src/agent.mcp.test.ts
+++ b/packages/agent-kit/src/agent.mcp.test.ts
@@ -67,7 +67,7 @@ describe("mcp", () => {
     await agent.run("do a tool call test: call printf with hello world");
   });
 });
-let instanceId = 1;
+let instanceId = 0;
 const newMCPServer = async (port: number) => {
   const server = new Server(
     {
@@ -106,7 +106,11 @@ const newMCPServer = async (port: number) => {
           `Multiple instances created. this instanceId: ${instanceId}`
         );
       }
-      return request.params?.arguments?.format || "";
+      return {
+        content: [
+          { type: "text", text: `${request.params.arguments?.format}` },
+        ],
+      };
     } else {
       throw new Error("Resource not found");
     }

--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -394,16 +394,13 @@ export class Agent<T extends StateData> {
   // initMCP fetches all tools from the agent's MCP servers, adding them to the tool list.
   // This is all that's necessary in order to enable MCP tool use within agents
   private async initMCP() {
-    if (
-      !this.mcpServers ||
-      this._mcpClients.length === this.mcpServers.length
-    ) {
+    if (!this.mcpServers || this._mcpClients.length >= this.mcpServers.length) {
       return;
     }
 
     const promises = [];
     for (const server of this.mcpServers) {
-      await this.listMCPTools(server);
+      // await this.listMCPTools(server);
       promises.push(this.listMCPTools(server));
     }
 
@@ -415,6 +412,7 @@ export class Agent<T extends StateData> {
    */
   private async listMCPTools(server: MCP.Server) {
     const client = await this.mcpClient(server);
+    this._mcpClients.push(client);
     try {
       const results = await client.request(
         { method: "tools/list" },
@@ -497,7 +495,6 @@ export class Agent<T extends StateData> {
       // The transport closed.
       console.warn("mcp server disconnected", server, e);
     }
-    this._mcpClients.push(client);
     return client;
   }
 }


### PR DESCRIPTION
we shud use SSE transport sessionId's. in an agent/ network run?

as i understand MCP SSE better, I'll update the PR with a  fix for the bug it highlights. 