### PR TITLE
fix: openai response parsing bugs

### DIFF
--- a/.changeset/quiet-years-brake.md
+++ b/.changeset/quiet-years-brake.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Add safety checks to openai response parser

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -128,7 +128,7 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
         } as TextMessage,
       ];
     }
-    if (message.tool_calls.length > 0) {
+    if ((message.tool_calls?.length ?? 0) > 0) {
       return [
         ...acc,
         {

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -118,7 +118,7 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
         openAiStopReasonToStateStopReason[finish_reason ?? ""] || "stop",
     };
 
-    if (message.content) {
+    if (message.content && message.content.trim() !== "") {
       return [
         ...acc,
         {


### PR DESCRIPTION
This PR addresses two edge cases I was running into with the OpenAI adapter:

1. Empty Content Handling
   - Added explicit check for non-empty content using `message.content.trim() !== ""`
   - Prevents processing of messages that only contain whitespace
   - Was causing subsequent requests to error due to empty content

2. Optional Tool Calls
   - Added null-safe check for `message.tool_calls` using optional chaining
   - Replaces direct length check with `(message.tool_calls?.length ?? 0) > 0`
   - Prevents potential runtime errors when tool_calls is undefined

These changes improve the robustness of the OpenAI adapter by properly handling edge cases that could previously cause issues.