### PR TITLE
Export types from `index.ts`

### DIFF
--- a/.changeset/breezy-suits-enjoy.md
+++ b/.changeset/breezy-suits-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Export types

--- a/.changeset/wise-cups-scream.md
+++ b/.changeset/wise-cups-scream.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Export types from `index.ts`

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -6,3 +6,4 @@ export * from "./network";
 export * from "./state";
 export * from "./tool";
 export * from "./util";
+export * from "./types";


### PR DESCRIPTION
Adds an export from `types.ts` in the index file to allow access to `AgentResult`, `Message`, etc.