### PR TITLE
changed 'pnpm;' to 'pnpm i' in readme contributing guide

### DIFF
--- a/packages/agent-kit/README.md
+++ b/packages/agent-kit/README.md
@@ -518,7 +518,7 @@ pnpm -v # should be > 9.x
 2. Install dependencies:
 
 ```tsx
-pnpm;
+pnpm i
 ```
 
 3. Build the package or run tests:


### PR DESCRIPTION
Noticed that the contributing guide currently states that a user should enter:
`pnpm;`

to install dependencies when it really should be:
`pnpm i`

This PR updates our readme accordingly.