### PR TITLE
Adding recursive check for removing additionalProperties for gemini.

### DIFF
--- a/packages/agent-kit/src/adapters/gemini.test.ts
+++ b/packages/agent-kit/src/adapters/gemini.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "vitest";
+import { recursiveGeminiZodToJsonSchema } from "./gemini";
+
+// Utility to deep-clone objects without preserving references
+const clone = <T>(obj: T): T => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const cloned: T = JSON.parse(JSON.stringify(obj));
+  return cloned;
+};
+
+describe("recursiveGeminiZodToJsonSchema", () => {
+  test("should remove additionalProperties when truthy at the top level", () => {
+    const input = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+      required: ["name"],
+    };
+    const expected = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    };
+
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should remove additionalProperties when truthy from nested objects", () => {
+    const input = {
+      type: "object",
+      properties: {
+        user: {
+          type: "object",
+          properties: { id: { type: "number" } },
+          additionalProperties: true,
+        },
+        isActive: { type: "boolean" },
+      },
+      additionalProperties: true,
+    };
+    const expected = {
+      type: "object",
+      properties: {
+        user: {
+          type: "object",
+          properties: { id: { type: "number" } },
+        },
+        isActive: { type: "boolean" },
+      },
+    };
+
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should remove additionalProperties from objects within an array when truthy", () => {
+    const input = {
+      type: "array",
+      items: [
+        {
+          type: "object",
+          properties: { sku: { type: "string" } },
+          additionalProperties: true,
+        },
+        { type: "number" },
+        {
+          type: "object",
+          properties: { count: { type: "integer" } },
+          additionalProperties: true,
+        },
+        "a string",
+        null,
+        undefined,
+      ],
+      additionalProperties: "foo",
+    };
+    const expected = {
+      type: "array",
+      items: [
+        {
+          type: "object",
+          properties: { sku: { type: "string" } },
+        },
+        { type: "number" },
+        {
+          type: "object",
+          properties: { count: { type: "integer" } },
+        },
+        "a string",
+        null,
+        undefined,
+      ],
+    };
+
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should handle deeply nested objects and arrays", () => {
+    const input = {
+      level1: {
+        additionalProperties: true,
+        level2: {
+          prop: "value",
+          additionalProperties: true,
+          level3Array: [
+            { item: 1, additionalProperties: true },
+            { item: 2, otherProp: "data" },
+            { item: 3, level4: { final: true, additionalProperties: true } },
+            "stringInNestedArray",
+          ],
+        },
+      },
+    };
+    const expected = {
+      level1: {
+        level2: {
+          prop: "value",
+          level3Array: [
+            { item: 1 },
+            { item: 2, otherProp: "data" },
+            { item: 3, level4: { final: true } },
+            "stringInNestedArray",
+          ],
+        },
+      },
+    };
+
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should return the object unchanged if no additionalProperties exist", () => {
+    const input = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        details: {
+          type: "object",
+          properties: { age: { type: "number" } },
+        },
+      },
+      required: ["name"],
+    };
+    const inputClone = clone(input);
+
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(inputClone);
+  });
+
+  test("should handle empty objects correctly", () => {
+    const input = {};
+    const expected = {};
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should handle objects with null or undefined values correctly", () => {
+    const input = {
+      prop1: null,
+      prop2: undefined,
+      prop3: {
+        nested: null,
+        additionalProperties: true,
+      },
+      prop4: [null, undefined, { item: 1, additionalProperties: true }],
+    };
+    const expected = {
+      prop1: null,
+      prop2: undefined,
+      prop3: {
+        nested: null,
+      },
+      prop4: [null, undefined, { item: 1 }],
+    };
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should handle top-level arrays", () => {
+    const input = [
+      { foo: 1, additionalProperties: true },
+      { bar: 2, additionalProperties: false },
+      3,
+      null,
+      undefined,
+      "string",
+    ];
+    const expected = [{ foo: 1 }, { bar: 2 }, 3, null, undefined, "string"];
+    expect(recursiveGeminiZodToJsonSchema(input)).toEqual(expected);
+  });
+
+  test("should not modify the original input object", () => {
+    const input = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+      nested: { prop: "value", additionalProperties: true },
+      arr: [{ inner: true, additionalProperties: false }],
+    };
+    const inputClone = clone(input);
+
+    recursiveGeminiZodToJsonSchema(input);
+    expect(input).toEqual(inputClone);
+  });
+});

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -276,8 +276,6 @@ export const recursiveGeminiZodToJsonSchema = <T>(
 
 const geminiZodToJsonSchema = (zod: ZodSchema) => {
   let schema = zodToJsonSchema(zod, { target: "openApi3" });
-  // @ts-expect-error this prop does exists and Gemini don't like it
-  delete schema["additionalProperties"];
 
   schema = recursiveGeminiZodToJsonSchema(schema);
   return schema;


### PR DESCRIPTION
Adding recursive check for removing additionalProperties for those situations where our zod schema produces a json schema which have nested additionaProperties values, which gemini also doesn't like.

When using a zod schema such as:

```ts
const demoSchema = z.discriminatedUnion("entity", [
  z.object({
    entity: z.literal("thing one"),
    opts: z.object({
      opt1: z.enum([ "Current", "Report_Date" ])
    })
  }),
  z.object({
    entity: z.literal("thing 2"),
    opts: z.object({
      opt2: z.enum([ "Current", "Report_Date" ])
    })
  })
]);
```

it produces the json-schema:

```json
{
  "anyOf": [
    {
      "type": "object",
      "properties": {
        "entity": {
          "type": "string",
          "const": "thing one"
        },
        "opts": {
          "type": "object",
          "properties": {
            "opt1": {
              "type": "string",
              "enum": [
                "Current",
                "Report_Date"
              ]
            }
          },
          "required": [
            "opt1"
          ],
          "additionalProperties": false
        }
      },
      "required": [
        "entity",
        "opts"
      ],
      "additionalProperties": false
    },
    {
      "type": "object",
      "properties": {
        "entity": {
          "type": "string",
          "const": "thing 2"
        },
        "opts": {
          "type": "object",
          "properties": {
            "opt2": {
              "type": "string",
              "enum": [
                "Current",
                "Report_Date"
              ]
            }
          },
          "required": [
            "opt2"
          ],
          "additionalProperties": false
        }
      },
      "required": [
        "entity",
        "opts"
      ],
      "additionalProperties": false
    }
  ],
  "$schema": "http://json-schema.org/draft-07/schema#"
}
```

This json-schema includes nested additionalProperties, which gemini also does not seem to like, and which are not handled by your top level `delete schema["additionalProperties"]` statement.

```json
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \"additionalProperties\" at 'tools[0].function_declarations[2].parameters.properties[1].value': Cannot find field.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "tools[0].function_declarations[2].parameters.properties[1].value",
            "description": "Invalid JSON payload received. Unknown name \"additionalProperties\" at 'tools[0].function_declarations[2].parameters.properties[1].value': Cannot find field."
          }
        ]
      }
    ]
  }
}
```