### PR TITLE
Bug: State.clone is always resetting existing state

### DIFF
--- a/packages/agent-kit/src/state.ts
+++ b/packages/agent-kit/src/state.ts
@@ -135,7 +135,7 @@ export class State<T extends StateData> {
    * clone allows you to safely clone the state.
    */
   clone() {
-    const state = new State<T>(this.data);
+    const state = new State<T>({data: this.data});
     state._results = this._results.slice();
     state._messages = this._messages.slice();
     return state;


### PR DESCRIPTION
Refactoring gone wrong here it seems. The constructor args for `State` are `({data, messages})` (it was `(data)` before that), but it's been passed `state.data` object directly.

This causes issues when `NetworkRun` is created with a cloned state – it doesn't include any of the data from the state that exists in the `Network`.