### PR TITLE
Fix state preservation in AgentKit network execution

### DIFF
--- a/packages/agent-kit/src/state.ts
+++ b/packages/agent-kit/src/state.ts
@@ -135,7 +135,7 @@ export class State<T extends StateData> {
    * clone allows you to safely clone the state.
    */
   clone() {
-    const state = new State<T>(this.data);
+    const state = new State<T>({data: this.data});
     state._results = this._results.slice();
     state._messages = this._messages.slice();
     return state;


### PR DESCRIPTION
## Issue
When running a network with a predefined state, the values weren't being preserved during execution. Investigation revealed a bug in AgentKit's state cloning process where `data` properties were not properly transferred to the new state instance.

Logs showed the state was correctly initialized in the network:
```
_data: { username: 'meow-username' }
```

But during execution, an empty state was being created:
```
_data: {}
```

## Root Cause
The issue was in AgentKit's `clone()` method which wasn't properly handling the `data` object structure:

```typescript
clone() {
  const state = new _State(this.data);  // Problem: incorrect constructor parameter
  state._results = this._results.slice();
  state._messages = this._messages.slice();
  return state;
}
```

## Fix
We fixed the issue by modifying the `clone()` method to properly structure the data when creating a new state instance:

```typescript
clone() {
  const state = new _State({data: this.data});  // Correct: passing properly structured object
  state._results = this._results.slice();
  state._messages = this._messages.slice();
  return state;
}
```

Also the documentation needs to be updated, or new State needs to be adjusted.

This works:
```typescript
defaultState: new State<NetworkState>({
  data: {
    username: "meow-username"
  }
}),
``` 

While this throws a TS error:
```typescript
  defaultState: new State({
      username: "meow-username"
  }),
```
> Object literal may only specify known properties, and 'username' does not exist in type 'Constructor<NetworkState>'.ts(2353)

```