### PR TITLE
Fixed gemini response parsing & malformed function call error

### DIFF
--- a/.changeset/honest-toes-attack.md
+++ b/.changeset/honest-toes-attack.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Fixed Gemini adapter response parsing & malformed function call handling

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -71,6 +71,14 @@ export const responseParser: AgenticModel.ResponseParser<Gemini.AiModel> = (
   const messages: Message[] = [];
 
   for (const candidate of input.candidates ?? []) {
+    if (!candidate.content?.parts) {
+      if ((candidate.finishReason as string) === "MALFORMED_FUNCTION_CALL") {
+        throw new Error(
+          "Gemini returned MALFORMED_FUNCTION_CALL. This typically indicates an issue with tool/function call formatting. Check your tool definitions and parameters."
+        );
+      }
+      continue; // Skip candidates without parts
+    }
     for (const content of candidate.content.parts) {
       // user text
       if (candidate.content.role === "user" && "text" in content) {

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -71,12 +71,12 @@ export const responseParser: AgenticModel.ResponseParser<Gemini.AiModel> = (
   const messages: Message[] = [];
 
   for (const candidate of input.candidates ?? []) {
+    if ((candidate.finishReason as string) === "MALFORMED_FUNCTION_CALL") {
+      throw new Error(
+        "Gemini returned MALFORMED_FUNCTION_CALL. This typically indicates an issue with tool/function call formatting. Check your tool definitions and parameters."
+      );
+    }
     if (!candidate.content?.parts) {
-      if ((candidate.finishReason as string) === "MALFORMED_FUNCTION_CALL") {
-        throw new Error(
-          "Gemini returned MALFORMED_FUNCTION_CALL. This typically indicates an issue with tool/function call formatting. Check your tool definitions and parameters."
-        );
-      }
       continue; // Skip candidates without parts
     }
     for (const content of candidate.content.parts) {

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -72,9 +72,10 @@ export const responseParser: AgenticModel.ResponseParser<Gemini.AiModel> = (
 
   for (const candidate of input.candidates ?? []) {
     if ((candidate.finishReason as string) === "MALFORMED_FUNCTION_CALL") {
-      throw new Error(
-        "Gemini returned MALFORMED_FUNCTION_CALL. This typically indicates an issue with tool/function call formatting. Check your tool definitions and parameters."
+      console.warn(
+        "Gemini returned MALFORMED_FUNCTION_CALL, skipping this candidate. This typically indicates an issue with tool/function call formatting. Check your tool definitions and parameters."
       );
+      continue; // Skip this candidate but continue processing others
     }
     if (!candidate.content?.parts) {
       continue; // Skip candidates without parts


### PR DESCRIPTION
## Problem

AgentKit's Gemini adapter was causing a crash that completely blocked the execution of all Gemini-based agents. The error occurred when Gemini's API returned responses with empty content objects:

```
TypeError: candidate.content.parts is not iterable
at AgenticModel.responseParser (/node_modules/@inngest/agent-kit/src/adapters/gemini.ts:74:45)
```

### Root Cause
Gemini's API occasionally returns malformed responses where `candidate.content.parts` is undefined, particularly when `finishReason` is `"MALFORMED_FUNCTION_CALL"`. The response structure looks like:

```json
{
  "content": {},
  "finishReason": "MALFORMED_FUNCTION_CALL"
}
```

The existing code at line 74 attempted to iterate over `candidate.content.parts` without checking if it exists:

```typescript
for (const content of candidate.content.parts) { // Crashes when parts is undefined
```

## Solution

Implemented **graceful degradation** with defensive error handling to process malformed Gemini responses without crashing:
1. When `finishReason` is `"MALFORMED_FUNCTION_CALL"`, log a warning with debugging guidance and continue processing other candidates
2. Check if `candidate.content?.parts` exists before attempting to iterate
3. Process all valid candidates in a response, even if some are malformed

## How It Works Now

1. **Before**: Any missing `content.parts` would cause an immediate crash, stopping all processing
2. **After**: **Graceful Degradation Pattern**
   - `MALFORMED_FUNCTION_CALL` candidates → Warning logged, candidate skipped, processing continues
   - Missing parts for other reasons → Candidate skipped silently, processing continues  
   - Valid candidates → Processed normally as before
   - **Result**: System extracts maximum value from partial responses instead of failing completely

## Reference

This issue was also encountered and resolved by the Continue.dev team in [PR #5974](https://github.com/continuedev/continue/pull/5974), confirming this is a known Gemini API behavior that requires defensive handling. Our implementation extends their approach by processing all candidates instead of just the first, providing better recovery from partial failures.