### PR TITLE
Fix OpenAI parser dropping tool calls when messages contain both text and tool calls

### DIFF
--- a/.changeset/tall-lamps-listen.md
+++ b/.changeset/tall-lamps-listen.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+fixed issue with openai parser not handling responses with both text and tool call parts

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -95,10 +95,15 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
 
 /**
  * Parse a response from OpenAI output to internal network messages.
+ * 
+ * This function transforms OpenAI's response format into our internal Message format,
+ * handling both text responses and tool calls. It processes multiple choices if present
+ * and creates separate messages for text content and tool calls when both exist.
  */
 export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
   input
 ) => {
+  // Handle API errors first - throw immediately if the request failed
   if (input.error) {
     throw new Error(
       input.error.message ||
@@ -106,19 +111,26 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
     );
   }
 
+  // Process all choices from the OpenAI response using reduce to flatten into a single Message array
+  // OpenAI can return multiple choices, though typically only one is returned
   return (input?.choices ?? []).reduce<Message[]>((acc, choice) => {
     const { message, finish_reason } = choice;
+    
+    // Skip empty messages - can happen in some edge cases
     if (!message) {
       return acc;
     }
 
+    // Create base message properties shared by all message types
+    // Maps OpenAI's finish_reason to our internal stop_reason format
     const base = {
       role: choice.message.role,
       stop_reason:
         openAiStopReasonToStateStopReason[finish_reason ?? ""] || "stop",
     };
 
-    // Handle text content if present
+    // Handle text content - only create a text message if content exists and isn't empty/whitespace
+    // This check prevents empty content messages that can occur when only tool calls are present
     if (message.content && message.content.trim() !== "") {
       acc.push({
         ...base,
@@ -127,7 +139,8 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
       } as TextMessage);
     }
     
-    // Handle tool calls if present
+    // Handle tool calls - create a separate tool_call message containing all tools
+    // OpenAI can return multiple tool calls in a single response (parallel tool calling)
     if ((message.tool_calls?.length ?? 0) > 0) {
       acc.push({
         ...base,
@@ -137,7 +150,8 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
             type: "tool",
             id: tool.id,
             name: tool.function.name,
-            function: tool.function.name,
+            function: tool.function.name, // Duplicate for backward compatibility
+            // Use safe parser to handle OpenAI's JSON quirks (like backticks in strings)
             input: safeParseOpenAIJson(tool.function.arguments || "{}"),
           } as ToolMessage;
         }),

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -118,34 +118,32 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
         openAiStopReasonToStateStopReason[finish_reason ?? ""] || "stop",
     };
 
+    // Handle text content if present
     if (message.content && message.content.trim() !== "") {
-      return [
-        ...acc,
-        {
-          ...base,
-          type: "text",
-          content: message.content,
-        } as TextMessage,
-      ];
+      acc.push({
+        ...base,
+        type: "text",
+        content: message.content,
+      } as TextMessage);
     }
+    
+    // Handle tool calls if present
     if ((message.tool_calls?.length ?? 0) > 0) {
-      return [
-        ...acc,
-        {
-          ...base,
-          type: "tool_call",
-          tools: message.tool_calls.map((tool) => {
-            return {
-              type: "tool",
-              id: tool.id,
-              name: tool.function.name,
-              function: tool.function.name,
-              input: safeParseOpenAIJson(tool.function.arguments || "{}"),
-            } as ToolMessage;
-          }),
-        } as ToolCallMessage,
-      ];
+      acc.push({
+        ...base,
+        type: "tool_call",
+        tools: message.tool_calls.map((tool) => {
+          return {
+            type: "tool",
+            id: tool.id,
+            name: tool.function.name,
+            function: tool.function.name,
+            input: safeParseOpenAIJson(tool.function.arguments || "{}"),
+          } as ToolMessage;
+        }),
+      } as ToolCallMessage);
     }
+    
     return acc;
   }, []);
 };


### PR DESCRIPTION
The OpenAI response parser had a critical bug where messages containing both text content AND tool calls would drop the tool calls entirely. This happened because the parser used early returns in an `if/else if` pattern:

1. If a message had text content → return early with only `TextMessage`
2. If a message had tool calls → only check this if there was no text content
3. **Result**: Messages with both content AND tool calls would lose the tool calls

This led to:
- Tool calls being completely ignored
- Extra LLM API calls due to missing tool execution
- Increased token consumption and costs
- Broken agent workflows when models provide explanatory text alongside tool calls

---

### 🔧 Solution

Changed the response parser logic such as to avoid early returns and instead accumulate all messages:

**Before (broken):**
```typescript
if (message.content && message.content.trim() !== "") {
  return [...acc, textMessage]; // Early return drops tool calls!
}
if ((message.tool_calls?.length ?? 0) > 0) {
  return [...acc, toolCallMessage];
}
```

**After (fixed):**
```typescript
// Handle text content if present
if (message.content && message.content.trim() !== "") {
  acc.push(textMessage);
}

// Handle tool calls if present  
if ((message.tool_calls?.length ?? 0) > 0) {
  acc.push(toolCallMessage);
}
```

---

**Related Issue**: 