### PR TITLE
docs: fix broken link in guided tour section

### DIFF
--- a/docs/guided-tour/overview.mdx
+++ b/docs/guided-tour/overview.mdx
@@ -15,15 +15,15 @@ This guide features a Code Assistant that will will progressively evolve from a 
 
 Below are the different versions of our Code Assistant, each progressively adding more autonomy and complexity:
 
-<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v1</span> {"Explaining a given code file"}</div>} href="/ai-agents-in-practice/ai-workflows">
+<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v1</span> {"Explaining a given code file"}</div>} href="/guided-tour/ai-workflows">
 The first version starts as a AI workflow using a tool to provide a file as context to the LLM (RAG).
 </Card>
 
-<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v2</span> {"Performing complex code analysis"}</div>} href="/ai-agents-in-practice/agentic-workflows">
+<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v2</span> {"Performing complex code analysis"}</div>} href="/guided-tour/agentic-workflows">
  Then, we will add Agentic capabilities to our assistant to enable it more complex analysis.
 </Card>
 
-<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v3</span> {"Autonomously reviewing a pull request"}</div>} href="/ai-agents-in-practice/ai-agents">
+<Card title={<div className="flex items-center gap-2"><span className="border-primary dark:border-primary-light bg-primary/10 text-primary text-xs dark:text-primary-light dark:bg-primary-light/10 rounded-xl px-2 py-1">v3</span> {"Autonomously reviewing a pull request"}</div>} href="/guided-tour/ai-agents">
 Finally, we will add more autonomy to our assistant, transforming it into a semi-autonomous AI Agent.
 </Card>
 


### PR DESCRIPTION
Fixes broken link in Guided Tour docs

This PR fixes a broken link in the Guided Tour section. 
The link previously pointed to a non-existent page and has been updated 
to the correct destination.

Verified locally that clicking the link navigates to the correct page.

Since this is a small docs fix, I didn’t create a separate issue. 
Happy to open one if maintainers prefer.

The three code samples links were broken from the screenshot.

![Guided Tour Broken Link Fix](https://github.com/user-attachments/assets/4c158e9e-47ec-4b28-b6f1-e3d9056f3043)