### PR TITLE
fix: bundler retains json-schema-to-zod due to type import

### DIFF
--- a/.changeset/tall-apricots-thank.md
+++ b/.changeset/tall-apricots-thank.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Remove unused json-schema-to-zod require from bundled cjs

--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -1,4 +1,4 @@
-import { type JSONSchema } from "@dmitryrechkin/json-schema-to-zod";
+import type { JSONSchema } from "@dmitryrechkin/json-schema-to-zod";
 import { type AiAdapter } from "@inngest/ai";
 import { Client as MCPClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";


### PR DESCRIPTION
Follow up to issue: https://github.com/inngest/agent-kit/issues/155

### The Issue 
Currently index.cjs is being bundled a top level require to `@dmitryrechkin/json-schema-to-zod` despite it being "unused". 
<img width="655" height="50" alt="image" src="https://github.com/user-attachments/assets/360fa144-6055-4f36-a96a-09d6e4ae7289" />
Due to the dependency being an ESM module, this causes an error to be thrown: `Error [ERR_REQUIRE_ESM]: require() of ES Module /opt/render/project/src/node_modules/@dmitryrechkin/json-schema-to-zod/dist/index.js from /opt/render/project/src/jobs/node_modules/@inngest/agent-kit/dist/index.cjs not supported.`
The previous attempt to fix this switched to lazy loading the import, however an import { type JSONSchema } remained. These types of type imports are not always cleaned up by the bundler, as there might be non-type imports associated in the group. 

### Resolution
Simply convert this from `import { type JSONSchema }` to `import type { JSONSchema` so that the type import is correctly omitted from the resulting `.cjs` file.

When re-running build with this change applied 🪄 

https://github.com/user-attachments/assets/c3e4996d-d9a4-4d6a-8bc7-975bb84f34c1


