### PR TITLE
Improve support for reasoning models

### DIFF
--- a/.changeset/sixty-flowers-joke.md
+++ b/.changeset/sixty-flowers-joke.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Add support for reasoning models: extract reasoning/thinking content from OpenAI o-series and Anthropic extended thinking responses into a new `ReasoningMessage` type, stream reasoning deltas, and skip reasoning messages in outbound requests across all adapters.

--- a/packages/agent-kit/LICENSE.md
+++ b/packages/agent-kit/LICENSE.md
@@ -2,180 +2,180 @@
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   1. Definitions.
+1.  Definitions.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
 
-   END OF TERMS AND CONDITIONS
+END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
+APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
@@ -186,16 +186,16 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Inngest Inc.
+Copyright 2024 Inngest Inc.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/agent-kit/src/adapters/anthropic.test.ts
+++ b/packages/agent-kit/src/adapters/anthropic.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "vitest";
+import { responseParser, requestParser } from "./anthropic";
+import type { Message, ReasoningMessage } from "../types";
+
+describe("anthropic responseParser", () => {
+  test("should extract thinking blocks as ReasoningMessage with signature", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "Let me reason through this carefully...",
+          signature: "sig_abc123",
+        },
+        {
+          type: "text",
+          text: "The answer is 42.",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(2);
+
+    expect(result[0]).toEqual({
+      type: "reasoning",
+      role: "assistant",
+      content: "Let me reason through this carefully...",
+      signature: "sig_abc123",
+    });
+
+    expect(result[1]).toEqual({
+      type: "text",
+      role: "assistant",
+      content: "The answer is 42.",
+      stop_reason: "stop",
+    });
+  });
+
+  test("should handle thinking block without signature", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "Some reasoning...",
+        },
+        {
+          type: "text",
+          text: "Result.",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(2);
+
+    const reasoning = result[0] as ReasoningMessage;
+    expect(reasoning.type).toBe("reasoning");
+    expect(reasoning.content).toBe("Some reasoning...");
+    expect(reasoning.signature).toBeUndefined();
+  });
+
+  test("should handle thinking block with tool_use", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "I need to use a tool.",
+          signature: "sig_xyz",
+        },
+        {
+          type: "tool_use",
+          id: "tool_1",
+          name: "search",
+          input: { query: "test" },
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(2);
+
+    expect(result[0]!.type).toBe("reasoning");
+    expect(result[1]!.type).toBe("tool_call");
+  });
+
+  test("should handle response without thinking blocks (backward compat)", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Normal response.",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "text",
+      role: "assistant",
+      content: "Normal response.",
+      stop_reason: "stop",
+    });
+  });
+});
+
+describe("anthropic requestParser", () => {
+  const mockModel = {
+    options: {
+      model: "claude-sonnet-4-5-20250929",
+      defaultParameters: { max_tokens: 1024 },
+    },
+  } as never;
+
+  test("should filter out reasoning messages from request", () => {
+    const messages: Message[] = [
+      { type: "text", role: "system", content: "You are helpful." },
+      { type: "text", role: "user", content: "What is 2+2?" },
+      {
+        type: "reasoning",
+        role: "assistant",
+        content: "Let me think...",
+        signature: "sig_abc",
+      },
+      { type: "text", role: "assistant", content: "4" },
+    ];
+
+    const result = requestParser(mockModel, messages, [], "auto");
+
+    // System is extracted to top-level, remaining: user + assistant (reasoning skipped)
+    expect(result.system).toBe("You are helpful.");
+    const outMessages = result.messages as Array<{ role: string }>;
+    expect(outMessages).toHaveLength(2);
+    expect(outMessages[0]!.role).toBe("user");
+    // The last assistant message gets patched to "user" by Anthropic adapter
+    expect(outMessages[1]!.role).toBe("user");
+  });
+});

--- a/packages/agent-kit/src/adapters/anthropic.ts
+++ b/packages/agent-kit/src/adapters/anthropic.ts
@@ -10,7 +10,11 @@ import {
 } from "@inngest/ai";
 import { z } from "zod";
 import { type AgenticModel } from "../model";
-import { type Message, type ReasoningMessage, type TextMessage } from "../types";
+import {
+  type Message,
+  type ReasoningMessage,
+  type TextMessage,
+} from "../types";
 import { type Tool } from "../tool";
 
 /**

--- a/packages/agent-kit/src/adapters/anthropic.ts
+++ b/packages/agent-kit/src/adapters/anthropic.ts
@@ -10,7 +10,7 @@ import {
 } from "@inngest/ai";
 import { z } from "zod";
 import { type AgenticModel } from "../model";
-import { type Message, type TextMessage } from "../types";
+import { type Message, type ReasoningMessage, type TextMessage } from "../types";
 import { type Tool } from "../tool";
 
 /**
@@ -39,6 +39,8 @@ export const requestParser: AgenticModel.RequestParser<Anthropic.AiModel> = (
           m: Message
         ): AiAdapter.Input<Anthropic.AiModel>["messages"] => {
           switch (m.type) {
+            case "reasoning":
+              return acc; // Skip reasoning in outbound requests
             case "text":
               return [
                 ...acc,
@@ -134,6 +136,19 @@ export const responseParser: AgenticModel.ResponseParser<Anthropic.AiModel> = (
   return (input?.content ?? []).reduce<Message[]>((acc, item) => {
     if (!item.type) {
       return acc;
+    }
+
+    // Handle thinking blocks which aren't in @inngest/ai types yet
+    if ((item.type as string) === "thinking") {
+      return [
+        ...acc,
+        {
+          type: "reasoning",
+          role: "assistant",
+          content: (item as unknown as { thinking: string }).thinking,
+          signature: (item as unknown as { signature?: string }).signature,
+        } as ReasoningMessage,
+      ];
     }
 
     switch (item.type) {

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -144,6 +144,11 @@ export const responseParser: AgenticModel.ResponseParser<Gemini.AiModel> = (
 const messageToContent = (
   m: Message
 ): AiAdapter.Input<Gemini.AiModel>["contents"][0] => {
+  // Skip reasoning messages - return empty parts which Gemini will ignore
+  if (m.type === "reasoning") {
+    return { role: "model", parts: [] };
+  }
+
   switch (m.role) {
     case "system":
       return {

--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "vitest";
+import { responseParser, requestParser, isReasoningModel } from "./openai";
+import type { Message, ReasoningMessage } from "../types";
+
+describe("openai responseParser", () => {
+  test("should extract reasoning_content and text from a response", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "The answer is 42.",
+            reasoning_content: "Let me think about this step by step...",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(2);
+
+    expect(result[0]).toEqual({
+      type: "reasoning",
+      role: "assistant",
+      content: "Let me think about this step by step...",
+    });
+
+    expect(result[1]).toEqual({
+      type: "text",
+      role: "assistant",
+      content: "The answer is 42.",
+      stop_reason: "stop",
+    });
+  });
+
+  test("should handle reasoning-only response (no text content)", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            reasoning_content: "Deep reasoning here...",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "reasoning",
+      role: "assistant",
+      content: "Deep reasoning here...",
+    });
+  });
+
+  test("should not create reasoning message when reasoning_content is empty", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Hello!",
+            reasoning_content: "   ",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe("text");
+  });
+
+  test("should handle response without reasoning_content (backward compat)", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Just a normal response.",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "text",
+      role: "assistant",
+      content: "Just a normal response.",
+      stop_reason: "stop",
+    });
+  });
+
+  test("should handle reasoning_content with tool calls", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            reasoning_content: "I need to call a tool to get the data.",
+            tool_calls: [
+              {
+                id: "call_123",
+                type: "function",
+                function: {
+                  name: "get_data",
+                  arguments: '{"query": "test"}',
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(2);
+
+    expect(result[0]!.type).toBe("reasoning");
+    expect((result[0] as ReasoningMessage).content).toBe(
+      "I need to call a tool to get the data."
+    );
+
+    expect(result[1]!.type).toBe("tool_call");
+  });
+});
+
+describe("openai requestParser", () => {
+  const mockModel = {
+    options: { model: "gpt-4" },
+  } as never;
+
+  test("should filter out reasoning messages from request", () => {
+    const messages: Message[] = [
+      { type: "text", role: "system", content: "You are helpful." },
+      { type: "text", role: "user", content: "What is 2+2?" },
+      { type: "reasoning", role: "assistant", content: "Let me think..." },
+      { type: "text", role: "assistant", content: "4" },
+    ];
+
+    const result = requestParser(mockModel, messages, [], "auto");
+    const outMessages = result.messages as Array<{ role: string; content: string }>;
+
+    expect(outMessages).toHaveLength(3);
+    expect(outMessages[0]!.role).toBe("system");
+    expect(outMessages[1]!.role).toBe("user");
+    expect(outMessages[2]!.role).toBe("assistant");
+    expect(outMessages[2]!.content).toBe("4");
+  });
+
+  test("should not set parallel_tool_calls for reasoning models", () => {
+    const o3Model = {
+      options: { model: "o3-mini" },
+    } as never;
+
+    const tools = [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        handler: async () => "result",
+      },
+    ];
+
+    const result = requestParser(o3Model, [], tools, "auto");
+    expect(result.parallel_tool_calls).toBeUndefined();
+  });
+
+  test("should set parallel_tool_calls=false for non-reasoning models", () => {
+    const gpt4Model = {
+      options: { model: "gpt-4o" },
+    } as never;
+
+    const tools = [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        handler: async () => "result",
+      },
+    ];
+
+    const result = requestParser(gpt4Model, [], tools, "auto");
+    expect(result.parallel_tool_calls).toBe(false);
+  });
+});
+
+describe("isReasoningModel", () => {
+  test("should detect o-series models", () => {
+    expect(isReasoningModel("o1")).toBe(true);
+    expect(isReasoningModel("o1-mini")).toBe(true);
+    expect(isReasoningModel("o1-preview")).toBe(true);
+    expect(isReasoningModel("o3")).toBe(true);
+    expect(isReasoningModel("o3-mini")).toBe(true);
+    expect(isReasoningModel("o4-mini")).toBe(true);
+  });
+
+  test("should detect gpt reasoning variants", () => {
+    expect(isReasoningModel("gpt-5-pro")).toBe(true);
+    expect(isReasoningModel("gpt-5.1-pro")).toBe(true);
+    expect(isReasoningModel("gpt-5.1-codex")).toBe(true);
+  });
+
+  test("should not detect regular models as reasoning", () => {
+    expect(isReasoningModel("gpt-4")).toBe(false);
+    expect(isReasoningModel("gpt-4o")).toBe(false);
+    expect(isReasoningModel("gpt-4o-mini")).toBe(false);
+    expect(isReasoningModel("gpt-4-turbo")).toBe(false);
+  });
+
+  test("should handle undefined and empty string", () => {
+    expect(isReasoningModel(undefined)).toBe(false);
+    expect(isReasoningModel("")).toBe(false);
+  });
+
+  test("should be case insensitive", () => {
+    expect(isReasoningModel("O3-Mini")).toBe(true);
+    expect(isReasoningModel("GPT-5-PRO")).toBe(true);
+  });
+});

--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -170,7 +170,7 @@ describe("openai requestParser", () => {
       {
         name: "test_tool",
         description: "A test tool",
-        handler: async () => "result",
+        handler: () => "result",
       },
     ];
 
@@ -187,7 +187,7 @@ describe("openai requestParser", () => {
       {
         name: "test_tool",
         description: "A test tool",
-        handler: async () => "result",
+        handler: () => "result",
       },
     ];
 

--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -149,7 +149,10 @@ describe("openai requestParser", () => {
     ];
 
     const result = requestParser(mockModel, messages, [], "auto");
-    const outMessages = result.messages as Array<{ role: string; content: string }>;
+    const outMessages = result.messages as Array<{
+      role: string;
+      content: string;
+    }>;
 
     expect(outMessages).toHaveLength(3);
     expect(outMessages[0]!.role).toBe("system");

--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -475,9 +475,7 @@ export class Agent<T extends StateData> {
 
     // Stream reasoning content if streaming context exists
     if (streamingContext) {
-      const reasoningMsgs = result.output.filter(
-        (m) => m.type === "reasoning"
-      );
+      const reasoningMsgs = result.output.filter((m) => m.type === "reasoning");
       for (const msg of reasoningMsgs) {
         if (msg.type !== "reasoning") continue;
 

--- a/packages/agent-kit/src/types.ts
+++ b/packages/agent-kit/src/types.ts
@@ -1,6 +1,10 @@
 import xxh from "xxhashjs";
 
-export type Message = TextMessage | ToolCallMessage | ToolResultMessage;
+export type Message =
+  | TextMessage
+  | ToolCallMessage
+  | ToolResultMessage
+  | ReasoningMessage;
 
 /**
  * UserMessage represents a rich message object from a client that can contain
@@ -62,6 +66,17 @@ export interface ToolResultMessage {
   tool: ToolMessage;
   content: unknown;
   stop_reason: "tool";
+}
+
+/**
+ * ReasoningMessage represents reasoning or thinking content from a model,
+ * such as OpenAI's reasoning_content or Anthropic's thinking blocks.
+ */
+export interface ReasoningMessage {
+  type: "reasoning";
+  role: "assistant";
+  content: string;
+  signature?: string; // Anthropic thinking block signature
 }
 
 // Message content.


### PR DESCRIPTION
Changes and improvements include:

  - Add ReasoningMessage type to support reasoning/thinking content from OpenAI (o-series, gpt-*-pro/codex) and Anthropic (extended thinking) models
  - Extract reasoning_content from OpenAI responses and thinking blocks from Anthropic responses into the new message type
  - Filter reasoning messages from outbound requests across all adapters (OpenAI, Anthropic, Gemini)
  - Improve OpenAI reasoning model detection with isReasoningModel() helper, replacing hardcoded o1/o3 checks
  - Fix potential infinite loop in agent run loop when model output contains only reasoning messages (no stop_reason)
  - Stream reasoning content via reasoning.delta events when streaming is enabled