### PR TITLE
docs: fix UI Streaming link in overview

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -17,7 +17,7 @@ With AgentKit, you get:
 
 🔌 **Integrates** with your favorite AI libraries and products (ex: [E2B](/integrations/e2b), [Browserbase](/integrations/browserbase), [Smithery](/integrations/smithery), [Daytona](/integrations/daytona)).
 
-⚡ **Stream live updates** to your UI with [UI Streaming](/advanced-patterns/ui-streaming).
+⚡ **Stream live updates** to your UI with [UI Streaming](/advanced-patterns/legacy-ui-streaming).
 
 📊 **[Local Live traces](/getting-started/local-development) and input/output logs** when combined with the Inngest Dev Server.
 


### PR DESCRIPTION
## Fix broken UI Streaming link in Overview

The **UI Streaming** link on the Overview page was pointing to
`/advanced-patterns/ui-streaming`, which no longer exists and results in a 404.

The legacy UI streaming docs are still available under
`/advanced-patterns/legacy-ui-streaming`, so this PR updates the link to point
to the correct location.

### What changed
- Updated `docs/overview.mdx` to replace  
  `/advanced-patterns/ui-streaming` with  
  `/advanced-patterns/legacy-ui-streaming`

### Verification
- Confirmed `/advanced-patterns/legacy-ui-streaming` loads correctly
- Verified the Overview page link no longer returns a 404

No issue was opened since this is a small, straightforward documentation fix.
