### PR TITLE
fix: add unique suffix to generate-agent-ids step ID to prevent Innge…

### DIFF
--- a/.changeset/lemon-islands-exist.md
+++ b/.changeset/lemon-islands-exist.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Fix network step ID collision that caused execution to hang after 9 steps

--- a/packages/agent-kit/src/network.ts
+++ b/packages/agent-kit/src/network.ts
@@ -642,7 +642,7 @@ export class NetworkRun<T extends StateData> extends Network<T> {
         if (stepTools) {
           // Use Inngest steps for deterministic agent ID generation
           const agentIds = await stepTools.run(
-            `generate-agent-ids-${this._counter}`,
+            `generate-agent-ids-${this._counter}-${Date.now()}`,
             () => {
               return {
                 agentRunId: generateId(),


### PR DESCRIPTION
…st replay collision

Problem: generate-agent-ids-${this._counter} produces deterministic step IDs. Since Inngest replays the entire function from scratch after every step completion, these IDs repeat across replays, causing a step ID collision that permanently hangs execution after 9 steps.

Fix: Add Date.now() to make each step ID unique per replay cycle.
Reproduction: Any createNetwork run with 10+ total steps (router calls + agent calls) hangs on the Execution step indefinitely.