### PR TITLE
fix: include reasoning_content in OpenAI adapter for DeepSeek multi-turn compatibility

### DIFF
--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -140,7 +140,7 @@ describe("openai requestParser", () => {
     options: { model: "gpt-4" },
   } as never;
 
-  test("should filter out reasoning messages from request", () => {
+  test("should include reasoning_content in assistant message for DeepSeek compatibility", () => {
     const messages: Message[] = [
       { type: "text", role: "system", content: "You are helpful." },
       { type: "text", role: "user", content: "What is 2+2?" },
@@ -152,6 +152,7 @@ describe("openai requestParser", () => {
     const outMessages = result.messages as Array<{
       role: string;
       content: string;
+      reasoning_content?: string;
     }>;
 
     expect(outMessages).toHaveLength(3);
@@ -159,6 +160,57 @@ describe("openai requestParser", () => {
     expect(outMessages[1]!.role).toBe("user");
     expect(outMessages[2]!.role).toBe("assistant");
     expect(outMessages[2]!.content).toBe("4");
+    expect(outMessages[2]!.reasoning_content).toBe("Let me think...");
+  });
+
+  test("should include reasoning_content in tool_call message", () => {
+    const messages: Message[] = [
+      { type: "text", role: "user", content: "Get me data" },
+      { type: "reasoning", role: "assistant", content: "I should call a tool" },
+      {
+        type: "tool_call",
+        role: "assistant",
+        stop_reason: "tool",
+        tools: [
+          {
+            type: "tool",
+            id: "call_123",
+            name: "get_data",
+            input: { query: "test" },
+          },
+        ],
+      },
+    ];
+
+    const result = requestParser(mockModel, messages, [], "auto");
+    const outMessages = result.messages as Array<{
+      role: string;
+      content: string | null;
+      reasoning_content?: string;
+      tool_calls?: unknown[];
+    }>;
+
+    expect(outMessages).toHaveLength(2);
+    expect(outMessages[1]!.role).toBe("assistant");
+    expect(outMessages[1]!.reasoning_content).toBe("I should call a tool");
+    expect(outMessages[1]!.tool_calls).toBeDefined();
+  });
+
+  test("should handle reasoning without following text message", () => {
+    const messages: Message[] = [
+      { type: "text", role: "user", content: "Hello" },
+      { type: "reasoning", role: "assistant", content: "Thinking..." },
+    ];
+
+    const result = requestParser(mockModel, messages, [], "auto");
+    const outMessages = result.messages as Array<{
+      role: string;
+      content: string;
+    }>;
+
+    // Reasoning without a following assistant message should be dropped
+    expect(outMessages).toHaveLength(1);
+    expect(outMessages[0]!.role).toBe("user");
   });
 
   test("should not set parallel_tool_calls for reasoning models", () => {

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -26,19 +26,32 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
   tools,
   tool_choice = "auto"
 ) => {
+  // Track pending reasoning content to attach to the next assistant message
+  // This is required for DeepSeek and other reasoning models in multi-turn conversations
+  let pendingReasoning: string | undefined;
+
   const request: AiAdapter.Input<OpenAi.AiModel> = {
     messages: messages
       .map((m: Message) => {
         switch (m.type) {
           case "reasoning":
+            pendingReasoning = m.content;
             return null;
-          case "text":
-            return {
+          case "text": {
+            const textMsg = {
               role: m.role,
               content: m.content,
             };
-          case "tool_call":
-            return {
+            if (m.role === "assistant" && pendingReasoning) {
+              Object.assign(textMsg, {
+                reasoning_content: pendingReasoning,
+              });
+              pendingReasoning = undefined;
+            }
+            return textMsg;
+          }
+          case "tool_call": {
+            const toolCallMsg = {
               role: "assistant",
               content: null,
               tool_calls: m.tools
@@ -52,6 +65,14 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
                   }))
                 : undefined,
             };
+            if (pendingReasoning) {
+              Object.assign(toolCallMsg, {
+                reasoning_content: pendingReasoning,
+              });
+              pendingReasoning = undefined;
+            }
+            return toolCallMsg;
+          }
           case "tool_result":
             return {
               role: "tool",


### PR DESCRIPTION
## Summary

- Fix OpenAI request parser to include `reasoning_content` field in assistant messages for DeepSeek multi-turn compatibility
- Add tests for reasoning content injection into text and tool_call messages

## Context

Fixes #317

When using DeepSeek models via the OpenAI-compatible adapter, multi-turn conversations were broken because the `reasoning_content` field from previous responses was being filtered out entirely. DeepSeek's reasoning mode requires this field to be passed back in subsequent requests.

This change captures reasoning content and attaches it to the next assistant message (text or tool_call), enabling proper DeepSeek reasoning mode across multiple turns.

---
*This contribution was created using opencode with the qwen3.6-plus-free model.*