### PR TITLE
fix(agent-kit): pass MCP tool schemas through adapters as JSON Schema

### DIFF
--- a/.changeset/quiet-tigers-flow.md
+++ b/.changeset/quiet-tigers-flow.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Fix MCP tools crashing with `TypeError: Cannot read properties of undefined (reading 'def')`. MCP tool input schemas are now passed through to the model adapters as JSON Schema instead of being run through a JSON Schema -> Zod -> JSON Schema round-trip that produced a schema incompatible with the Zod version used by the adapters.

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -47,7 +47,6 @@
     }
   },
   "dependencies": {
-    "@dmitryrechkin/json-schema-to-zod": "^1.0.0",
     "@inngest/ai": "0.1.6",
     "@modelcontextprotocol/sdk": "^1.11.2",
     "eventsource": "^3.0.2",

--- a/packages/agent-kit/pnpm-lock.yaml
+++ b/packages/agent-kit/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
 
   .:
     dependencies:
-      '@dmitryrechkin/json-schema-to-zod':
-        specifier: ^1.0.0
-        version: 1.0.1
       '@inngest/ai':
         specifier: 0.1.6
         version: 0.1.6
@@ -83,9 +80,6 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-
-  '@dmitryrechkin/json-schema-to-zod@1.0.1':
-    resolution: {integrity: sha512-cG9gC4NMu/7JZqmRZy6uIb+l+kxek2GFQ0/qrhw7xeFK2l5B9yF9FVuujoqFPLRGDHNFYqtBWht7hY4KB0ngrA==}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -1622,6 +1616,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -1706,6 +1701,7 @@ packages:
   inngest@3.43.1:
     resolution: {integrity: sha512-zG+BuENQFPUFNVM2sZRRhDXDTh3PAH6KPuus9a/ZTu7LGnAvE+HvHZFmRcBND2LFN6phQ6sIyqB34LV90wg3IA==}
     engines: {node: '>=20'}
+    deprecated: 'CRITICAL SECURITY: upgrade to >=3.54.0'
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
       '@vercel/node': '>=2.15.9'
@@ -2473,6 +2469,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -2634,10 +2631,6 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-
-  '@dmitryrechkin/json-schema-to-zod@1.0.1':
-    dependencies:
-      zod: 3.25.76
 
   '@esbuild/aix-ppc64@0.25.10':
     optional: true

--- a/packages/agent-kit/src/adapters/anthropic.ts
+++ b/packages/agent-kit/src/adapters/anthropic.ts
@@ -113,9 +113,10 @@ export const requestParser: AgenticModel.RequestParser<Anthropic.AiModel> = (
           ? z.toJSONSchema(t.parameters, {
               target: "draft-2020-12",
             })
-          : z.toJSONSchema(z.object({}), {
+          : (t.mcp?.tool?.inputSchema ??
+            z.toJSONSchema(z.object({}), {
               target: "draft-2020-12",
-            })) as AnthropicAiAdapter.Tool.InputSchema,
+            }))) as AnthropicAiAdapter.Tool.InputSchema,
       };
     });
     request.tool_choice = toolChoice(tool_choice);

--- a/packages/agent-kit/src/adapters/gemini.ts
+++ b/packages/agent-kit/src/adapters/gemini.ts
@@ -28,8 +28,13 @@ export const requestParser: AgenticModel.RequestParser<Gemini.AiModel> = (
     description: t.description,
     parameters: t.parameters
       ? geminiZodToJsonSchema(t.parameters)
-      : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (geminiZodToJsonSchema(z.object({})) as any),
+      : t.mcp?.tool?.inputSchema
+        ? // MCP tools already expose a JSON Schema; strip the fields Gemini
+          // does not accept and pass it through directly.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (recursiveGeminiZodToJsonSchema(t.mcp.tool.inputSchema) as any)
+        : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (geminiZodToJsonSchema(z.object({})) as any),
   }));
 
   return {

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -83,8 +83,9 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
         function: {
           name: t.name,
           description: t.description,
-          parameters:
-            t.parameters && z.toJSONSchema(t.parameters, { target: "draft-7" }),
+          parameters: t.parameters
+            ? z.toJSONSchema(t.parameters, { target: "draft-7" })
+            : t.mcp?.tool?.inputSchema,
           strict:
             typeof t.strict !== "undefined" ? t.strict : Boolean(t.parameters), // strict mode is only supported with parameters
         },

--- a/packages/agent-kit/src/agent.mcp.test.ts
+++ b/packages/agent-kit/src/agent.mcp.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { describe, expect, test } from "vitest";
 import { Agent } from "./agent";
+import { requestParser as anthropicRequestParser } from "./adapters/anthropic";
+import { requestParser as openaiRequestParser } from "./adapters/openai";
+import { requestParser as geminiRequestParser } from "./adapters/gemini";
 // MCP server tests
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -73,6 +76,58 @@ describe("mcp", () => {
     expect(agent.tools.size).toEqual(0);
     await agent["initMCP"]();
     expect(agent.tools.size).toEqual(1);
+  });
+
+  test("MCP tool schema flows through model adapters without crashing", async () => {
+    await newMCPServer(3002, createStreamableHTTPTransport);
+
+    const agent = new Agent({
+      name: "test",
+      system: "noop",
+      mcpServers: [
+        {
+          name: "test",
+          transport: {
+            type: "streamable-http",
+            url: "http://localhost:3002/mcp",
+          },
+        },
+      ],
+    });
+
+    await agent["initMCP"]();
+    const tools = Array.from(agent.tools.values());
+    expect(tools).toHaveLength(1);
+
+    const mockModel = {
+      options: {
+        model: "test-model",
+        defaultParameters: { max_tokens: 1024 },
+      },
+    } as never;
+
+    // Each adapter builds the LLM request from the tool's schema. This used to
+    // throw "Cannot read properties of undefined (reading 'def')" because the
+    // MCP schema was produced by a Zod v3 converter incompatible with Zod v4's
+    // toJSONSchema().
+    expect(() =>
+      anthropicRequestParser(mockModel, [], tools, "auto")
+    ).not.toThrow();
+    expect(() =>
+      openaiRequestParser(mockModel, [], tools, "auto")
+    ).not.toThrow();
+    expect(() =>
+      geminiRequestParser(mockModel, [], tools, "auto")
+    ).not.toThrow();
+
+    const anthropicReq = anthropicRequestParser(mockModel, [], tools, "auto");
+    const inputSchema = (
+      anthropicReq.tools as Array<{
+        input_schema: { type: string; properties?: Record<string, unknown> };
+      }>
+    )[0]!.input_schema;
+    expect(inputSchema.type).toBe("object");
+    expect(inputSchema.properties).toHaveProperty("format");
   });
 
   // });

--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -1,4 +1,3 @@
-import type { JSONSchema } from "@dmitryrechkin/json-schema-to-zod";
 import { type AiAdapter } from "@inngest/ai";
 import { Client as MCPClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -13,7 +12,6 @@ import { referenceFunction, type Inngest, type GetStepTools } from "inngest";
 import { errors } from "inngest/internals";
 import { type InngestFunction } from "inngest";
 import { type MinimalEventPayload } from "inngest/types";
-import type { ZodType } from "zod";
 import { createAgenticModelFromAiAdapter, type AgenticModel } from "./model";
 import { createNetwork, NetworkRun } from "./network";
 import { State, type StateData } from "./state";
@@ -898,9 +896,6 @@ export class Agent<T extends StateData> {
    * listMCPTools lists all available tools for a given MCP server
    */
   private async listMCPTools(server: MCP.Server) {
-    const { JSONSchemaToZod } = await import(
-      "@dmitryrechkin/json-schema-to-zod"
-    );
     const client = await this.mcpClient(server);
     this._mcpClients.push(client);
     try {
@@ -911,23 +906,14 @@ export class Agent<T extends StateData> {
       results.tools.forEach((t) => {
         const name = `${server.name}-${t.name}`;
 
-        let zschema: undefined | ZodType;
-        try {
-          // The converter may return a Zod v3 schema type; coerce to v4 type or fallback
-          zschema = JSONSchemaToZod.convert(
-            t.inputSchema as JSONSchema
-          ) as unknown as ZodType;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (e) {
-          // Do nothing here.
-          zschema = undefined;
-        }
-
-        // Add the MCP tools directly to the tool set.
+        // MCP tools already provide a JSON Schema for their input. The raw
+        // schema is kept on `mcp.tool.inputSchema` and passed through to the
+        // model adapters as-is, avoiding a lossy JSON Schema -> Zod -> JSON
+        // Schema round-trip that previously produced a schema incompatible
+        // with the agent-kit Zod version.
         this.tools.set(name, {
           name: name,
           description: t.description,
-          parameters: zschema,
           mcp: {
             server,
             tool: t,


### PR DESCRIPTION
## Summary

Fixes #312.

MCP tools crash with `TypeError: Cannot read properties of undefined (reading 'def')`
when `network.run()` builds an LLM request. `listMCPTools` converts each MCP tool's
JSON Schema into a Zod schema via `@dmitryrechkin/json-schema-to-zod`, which bundles
Zod v3, but the model adapters call Zod v4's `toJSONSchema()` on those schemas. v4's
`toJSONSchema()` reads `.def`, which doesn't exist on a v3 schema, so it throws.

MCP tools already expose a JSON Schema on `mcp.tool.inputSchema`, so the
JSON Schema -> Zod -> JSON Schema round-trip is unnecessary. This PR:

- stops producing the incompatible Zod schema in `listMCPTools` and keeps the raw
  `mcp.tool.inputSchema` on the tool;
- has the Anthropic, OpenAI, and Gemini adapters fall back to that raw schema when
  `parameters` is absent (the Gemini path still strips fields Gemini rejects);
- removes the now-unused `@dmitryrechkin/json-schema-to-zod` dependency, which was the
  source of the Zod v3/v4 mismatch.

## Test plan

- [x] Added a test that starts an MCP server, runs `initMCP`, and verifies the tool
      flows through all three adapters' `requestParser` without throwing (fails before
      this change, passes after).
- [x] `pnpm --filter @inngest/agent-kit test` — all green.
- [x] Build, lint, and type-check pass.
- [x] Existing `createTool`/Zod-parameter tests still pass (non-MCP path unaffected).