### PR TITLE
Add OrcaRouter model support

### DIFF
--- a/.changeset/orcarouter-model-support.md
+++ b/.changeset/orcarouter-model-support.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": minor
+---
+
+Add OrcaRouter model support via a new `orcarouter()` helper. OrcaRouter is an OpenAI-compatible LLM router, so the helper reuses the `openai-chat` adapter and defaults the base URL to `https://api.orcarouter.ai/v1` and the API key to the `ORCAROUTER_API_KEY` environment variable. Pass `orcarouter/auto` to use OrcaRouter's adaptive routing.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -156,6 +156,7 @@ export default defineConfig({
             { label: "Anthropic", slug: "reference/model-anthropic" },
             { label: "Gemini", slug: "reference/model-gemini" },
             { label: "Grok", slug: "reference/model-grok" },
+            { label: "OrcaRouter", slug: "reference/model-orcarouter" },
           ],
         },
         {

--- a/docs/src/content/docs/concepts/models.mdx
+++ b/docs/src/content/docs/concepts/models.mdx
@@ -222,6 +222,23 @@ For a full list of supported models, you can always check [the models directory 
 ```
 
 </TabItem>
+<TabItem label="OrcaRouter">
+
+```plaintext
+"orcarouter/auto"
+"openai/gpt-5.5"
+"google/gemini-3-flash-preview"
+"anthropic/claude-opus-4.7"
+"grok/grok-4.3"
+"deepseek/deepseek-v4-pro"
+"minimax/minimax-m2.7"
+"qwen/qwen3.6-flash"
+```
+
+OrcaRouter exposes 150+ models; any model ID can be passed as a free-form
+string. See the [full catalog](https://www.orcarouter.ai/models).
+
+</TabItem>
 </Tabs>
 
 ### Environment variable used for each model provider
@@ -230,6 +247,7 @@ For a full list of supported models, you can always check [the models directory 
 - Anthropic: `ANTHROPIC_API_KEY`
 - Gemini: `GEMINI_API_KEY`
 - Grok: `XAI_API_KEY`
+- OrcaRouter: `ORCAROUTER_API_KEY`
 
 ## Contribution
 

--- a/docs/src/content/docs/reference/model-orcarouter.mdx
+++ b/docs/src/content/docs/reference/model-orcarouter.mdx
@@ -1,0 +1,98 @@
+---
+title: OrcaRouter Model
+description: "Configure OrcaRouter as your model provider"
+---
+
+import ParamField from '../../../components/ParamField.astro';
+
+The `orcarouter` function configures [OrcaRouter](https://www.orcarouter.ai) as your model provider.
+
+OrcaRouter is an OpenAI-compatible LLM router that exposes 150+ upstream models
+behind a single endpoint, plus an adaptive `orcarouter/auto` router that picks
+an upstream per request. Because the API is OpenAI-compatible, `orcarouter`
+reuses the OpenAI adapter and only changes the default base URL and API key
+environment variable.
+
+```ts
+import { createAgent, orcarouter } from "@inngest/agent-kit";
+
+const agent = createAgent({
+  name: "Code writer",
+  system: "You are an expert TypeScript programmer.",
+  // `orcarouter/auto` lets OrcaRouter pick the best upstream per request.
+  model: orcarouter({ model: "orcarouter/auto" }),
+});
+```
+
+## Configuration
+
+The `orcarouter` function accepts a configuration object:
+
+```ts
+const agent = createAgent({
+  model: orcarouter({
+    model: "openai/gpt-5.5",
+    apiKey: process.env.ORCAROUTER_API_KEY,
+    baseUrl: "https://api.orcarouter.ai/v1",
+    defaultParameters: { temperature: 0.5 },
+  }),
+});
+```
+
+### Options
+
+<ParamField path="model" type="string" required>
+  ID of the model to use, e.g. `orcarouter/auto` or an upstream model such as
+  `openai/gpt-5.5`.
+
+  See the [OrcaRouter models list](https://www.orcarouter.ai/models).
+</ParamField>
+
+<ParamField path="apiKey" type="string">
+  The OrcaRouter API key to use for authenticating your request. By default
+  we'll search for and use the `ORCAROUTER_API_KEY` environment variable.
+</ParamField>
+
+<ParamField
+  path="baseUrl"
+  type="string"
+  default="https://api.orcarouter.ai/v1"
+>
+  The base URL for the OrcaRouter API.
+</ParamField>
+
+<ParamField path="defaultParameters" type="object">
+  The default parameters to use for the model (ex: `temperature`, `max_tokens`,
+  etc).
+</ParamField>
+
+### Adaptive routing
+
+Passing `orcarouter/auto` as the model uses OrcaRouter's adaptive router, which
+selects an upstream model per request based on the routing strategy configured
+in your [routing console](https://www.orcarouter.ai/console/routing). This lets
+a single endpoint route cheap requests to cheap models and demanding requests to
+premium models without any client-side logic.
+
+### Available models
+
+```plaintext OrcaRouter
+"orcarouter/auto"
+"openai/gpt-5.5"
+"google/gemini-3-flash-preview"
+"anthropic/claude-opus-4.7"
+"grok/grok-4.3"
+"deepseek/deepseek-v4-pro"
+"minimax/minimax-m2.7"
+"qwen/qwen3.6-flash"
+```
+
+Any of OrcaRouter's 150+ model IDs can also be passed as a free-form string. For
+the latest list, see the [OrcaRouter models catalog](https://www.orcarouter.ai/models).
+
+## Notes
+
+When using `orcarouter/auto` with tool-calling agents, make sure the router's
+upstream pool only contains tool-capable models (configurable in the
+[routing console](https://www.orcarouter.ai/console/routing)), or pin a specific
+tool-capable model such as `openai/gpt-5.5`.

--- a/packages/agent-kit/src/models.ts
+++ b/packages/agent-kit/src/models.ts
@@ -1,1 +1,3 @@
 export { anthropic, gemini, openai, grok } from "@inngest/ai";
+export { orcarouter } from "./orcarouter";
+export type { OrcaRouter } from "./orcarouter";

--- a/packages/agent-kit/src/orcarouter.test.ts
+++ b/packages/agent-kit/src/orcarouter.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { orcarouter } from "./orcarouter";
+
+describe("orcarouter model helper", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.ORCAROUTER_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("uses the openai-chat format (reuses the OpenAI adapter)", () => {
+    const model = orcarouter({ model: "orcarouter/auto" });
+    expect(model.format).toBe("openai-chat");
+  });
+
+  test("defaults to the OrcaRouter base URL", () => {
+    const model = orcarouter({ model: "orcarouter/auto" });
+    expect(model.url).toBe("https://api.orcarouter.ai/v1/chat/completions");
+  });
+
+  test("respects a custom base URL", () => {
+    const model = orcarouter({
+      model: "openai/gpt-5.5",
+      baseUrl: "https://gateway.internal/v1",
+    });
+    expect(model.url).toBe("https://gateway.internal/v1/chat/completions");
+  });
+
+  test("uses the explicitly provided apiKey", () => {
+    const model = orcarouter({
+      model: "orcarouter/auto",
+      apiKey: "sk-orca-explicit",
+    });
+    expect(model.authKey).toBe("sk-orca-explicit");
+  });
+
+  test("falls back to the ORCAROUTER_API_KEY environment variable", () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-from-env";
+    const model = orcarouter({ model: "orcarouter/auto" });
+    expect(model.authKey).toBe("sk-orca-from-env");
+  });
+
+  test("does not fall back to OPENAI_API_KEY", () => {
+    process.env.OPENAI_API_KEY = "sk-openai-should-not-leak";
+    const model = orcarouter({ model: "orcarouter/auto" });
+    expect(model.authKey).toBe("");
+  });
+
+  test("onCall sets the model and merges defaultParameters into the body", () => {
+    const model = orcarouter({
+      model: "orcarouter/auto",
+      defaultParameters: { temperature: 0.5 },
+    });
+
+    const body: Record<string, unknown> = { messages: [] };
+    model.onCall?.(model, body as never);
+
+    expect(body.model).toBe("orcarouter/auto");
+    expect(body.temperature).toBe(0.5);
+  });
+});

--- a/packages/agent-kit/src/orcarouter.ts
+++ b/packages/agent-kit/src/orcarouter.ts
@@ -1,0 +1,117 @@
+/**
+ * OrcaRouter model helper.
+ *
+ * OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible LLM router
+ * that exposes 150+ upstream models behind a single `/v1/chat/completions`
+ * endpoint, plus an adaptive `orcarouter/auto` router that picks an upstream
+ * per request. Because the API is OpenAI-compatible, this helper is a thin
+ * wrapper around the `openai` model: it reuses the `openai-chat` adapter and
+ * only changes the default base URL and the API key environment variable.
+ *
+ * @module
+ */
+
+import { type AiAdapter, type OpenAi, openai } from "@inngest/ai";
+
+/**
+ * Create an OrcaRouter model using the OpenAI-compatible chat format.
+ *
+ * By default it targets the `https://api.orcarouter.ai/v1` base URL and reads
+ * the API key from the `ORCAROUTER_API_KEY` environment variable.
+ *
+ * @example
+ * ```ts
+ * import { createAgent, orcarouter } from "@inngest/agent-kit";
+ *
+ * const agent = createAgent({
+ *   name: "Code writer",
+ *   system: "You are an expert TypeScript programmer.",
+ *   // `orcarouter/auto` lets OrcaRouter pick the best upstream per request.
+ *   model: orcarouter({ model: "orcarouter/auto" }),
+ * });
+ * ```
+ *
+ * @see https://docs.orcarouter.ai
+ */
+export const orcarouter: AiAdapter.ModelCreator<
+  [options: OrcaRouter.AiModelOptions],
+  OrcaRouter.AiModel
+> = (options) => {
+  const apiKey = options.apiKey || processEnv("ORCAROUTER_API_KEY") || "";
+  const baseUrl = options.baseUrl || "https://api.orcarouter.ai/v1";
+
+  const adapter = openai({
+    ...options,
+    apiKey,
+    baseUrl,
+    model: options.model,
+  });
+
+  // `openai()` falls back to `OPENAI_API_KEY` when no key is provided. We've
+  // already resolved the key from `ORCAROUTER_API_KEY`, so pin `authKey` to
+  // avoid silently sending an OpenAI key to the OrcaRouter endpoint.
+  adapter.authKey = apiKey;
+
+  return adapter;
+};
+
+/**
+ * Read an environment variable in a way that is safe across runtimes that may
+ * not define `process` (e.g. some edge runtimes).
+ */
+const processEnv = (key: string): string | undefined => {
+  return typeof process !== "undefined" ? process.env?.[key] : undefined;
+};
+
+export namespace OrcaRouter {
+  /**
+   * IDs of models to use.
+   *
+   * `orcarouter/auto` is OrcaRouter's adaptive router (not a single model): it
+   * selects an upstream per request based on your configured routing strategy.
+   * The other entries are flagship upstream models; any of OrcaRouter's 150+
+   * model IDs can also be passed as a free-form string.
+   *
+   * See the full catalog at https://www.orcarouter.ai/models.
+   */
+  export type Model =
+    | (string & {})
+    | "orcarouter/auto"
+    | "openai/gpt-5.5"
+    | "google/gemini-3-flash-preview"
+    | "anthropic/claude-opus-4.7"
+    | "grok/grok-4.3"
+    | "deepseek/deepseek-v4-pro"
+    | "minimax/minimax-m2.7"
+    | "qwen/qwen3.6-flash";
+
+  /**
+   * Options for creating an OrcaRouter model.
+   */
+  export interface AiModelOptions extends Omit<OpenAi.AiModelOptions, "model"> {
+    /**
+     * ID of the model to use. Defaults to no model; pass `orcarouter/auto` to
+     * let OrcaRouter pick the best upstream per request.
+     */
+    model: OrcaRouter.Model;
+
+    /**
+     * The OrcaRouter API key to use for authenticating your request. By default
+     * we'll search for and use the `ORCAROUTER_API_KEY` environment variable.
+     */
+    apiKey?: string;
+
+    /**
+     * The base URL for the OrcaRouter API.
+     *
+     * @default "https://api.orcarouter.ai/v1"
+     */
+    baseUrl?: string;
+  }
+
+  /**
+   * An OrcaRouter model. OrcaRouter is OpenAI-compatible, so it reuses the
+   * OpenAI model type and the `openai-chat` adapter.
+   */
+  export type AiModel = OpenAi.AiModel;
+}


### PR DESCRIPTION
## Summary

Adds an `orcarouter()` model helper for [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible LLM router that exposes 150+ upstream models behind a single endpoint, plus an adaptive `orcarouter/auto` router that picks an upstream per request.

Because OrcaRouter is OpenAI-compatible, the helper is a thin wrapper around the existing `openai` model: it reuses the `openai-chat` adapter and only changes the default base URL (`https://api.orcarouter.ai/v1`) and the API key environment variable (`ORCAROUTER_API_KEY`). This mirrors how `grok` is built on top of `openai`.

> Disclosure: I'm an engineer on the OrcaRouter team.

## Usage

```ts
import { createAgent, orcarouter } from "@inngest/agent-kit";

const agent = createAgent({
  name: "Code writer",
  system: "You are an expert TypeScript programmer.",
  // `orcarouter/auto` lets OrcaRouter pick the best upstream per request.
  model: orcarouter({ model: "orcarouter/auto" }),
});
The API key is read from ORCAROUTER_API_KEY by default, or can be passed explicitly via apiKey. Any of OrcaRouter's model IDs can be passed as a free-form string; orcarouter/auto uses the adaptive router configured in your routing console.

Changes
New orcarouter() helper (packages/agent-kit/src/orcarouter.ts), re-exported from models.ts.
Reuses the existing openai-chat adapter — no new adapter/format needed.
Pins authKey to the resolved OrcaRouter key so it never silently falls back to OPENAI_API_KEY.
Docs: new OrcaRouter reference page, Models concept page tab + env var list, sidebar entry.
Changeset (minor).
Testing
pnpm --filter @inngest/agent-kit type-check — passes
pnpm --filter @inngest/agent-kit test — passes (72 tests, incl. 7 new OrcaRouter tests covering format, base URL, API-key resolution, and onCall parameter merging)
pnpm --filter @inngest/agent-kit build — passes