### PR TITLE
fix(examples): replace local tarball path with latest in use-agent example

### DIFF
--- a/examples/use-agent/package.json
+++ b/examples/use-agent/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/react": "^2.0.12",
     "@hookform/resolvers": "^5.2.1",
     "@icons-pack/react-simple-icons": "^13.7.0",
-    "@inngest/agent-kit": "file:/Users/tedwerbel/Documents/code/agent-kit/packages/agent-kit/inngest-agent-kit-0.13.2.tgz",
+    "@inngest/agent-kit": "latest",
     "@inngest/realtime": "^0.4.0",
     "@inngest/use-agent": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/examples/use-agent/pnpm-lock.yaml
+++ b/examples/use-agent/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^13.7.0
         version: 13.7.0(react@19.1.0)
       '@inngest/agent-kit':
-        specifier: file:/Users/tedwerbel/Documents/code/agent-kit/packages/agent-kit/inngest-agent-kit-0.13.2.tgz
+        specifier: latest
         version: file:../../packages/agent-kit/inngest-agent-kit-0.13.2.tgz(inngest@3.43.1(express@5.1.0)(next@15.4.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(zod@4.1.11))(zod@4.1.11)
       '@inngest/realtime':
         specifier: ^0.4.0


### PR DESCRIPTION
## Problem

The @inngest/agent-kit dependency in examples/use-agent/package.json was accidentally committed pointing to an absolute path on the original developer local machine:

    file:/Users/tedwerbel/Documents/code/agent-kit/packages/agent-kit/inngest-agent-kit-0.13.2.tgz

This breaks npm/pnpm install for anyone cloning the repo.

## Fix

Replace the local file path with latest, matching the convention in other examples (quick-start, demo, etc.).

Also update the pnpm-lock.yaml specifier which had the same absolute path.

Closes #316