### PR TITLE
fix(anthropic): skip unmapped content blocks in responseParser

### DIFF
--- a/.changeset/anthropic-parser-default-case.md
+++ b/.changeset/anthropic-parser-default-case.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Fix the Anthropic response parser crashing on content blocks it does not map to a network message. The parser's `switch` handled only `text` and `tool_use` and had no `default` case, so an unrecognized block (for example `redacted_thinking`, or a block type added in a future API version) made the `reduce` callback return `undefined`; the next iteration's `...acc` spread then threw `Spread syntax requires ...iterable not be null or undefined`, failing the whole response parse. Unknown blocks are now skipped.

--- a/packages/agent-kit/src/adapters/anthropic.test.ts
+++ b/packages/agent-kit/src/adapters/anthropic.test.ts
@@ -106,6 +106,55 @@ describe("anthropic responseParser", () => {
       stop_reason: "stop",
     });
   });
+
+  test("should skip redacted_thinking blocks and still parse later blocks", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "redacted_thinking",
+          data: "EvQB... (encrypted)",
+        },
+        {
+          type: "text",
+          text: "Final answer.",
+        },
+      ],
+    };
+
+    // Before the default case this threw "Spread syntax requires ...iterable"
+    // because the unmapped block made the reducer return undefined.
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "text",
+      role: "assistant",
+      content: "Final answer.",
+      stop_reason: "stop",
+    });
+  });
+
+  test("should skip unknown block types without throwing", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "some_future_block_type",
+          foo: "bar",
+        },
+        {
+          type: "tool_use",
+          id: "tool_1",
+          name: "search",
+          input: { query: "test" },
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe("tool_call");
+  });
 });
 
 describe("anthropic requestParser", () => {

--- a/packages/agent-kit/src/adapters/anthropic.ts
+++ b/packages/agent-kit/src/adapters/anthropic.ts
@@ -197,6 +197,14 @@ export const responseParser: AgenticModel.ResponseParser<Anthropic.AiModel> = (
           },
         ];
       }
+      default:
+        // Anthropic can return content blocks we don't map to a network
+        // message (for example `redacted_thinking`, or block types added in
+        // future API versions). Skip them instead of falling through: without
+        // this case the callback returns `undefined`, and the next iteration's
+        // `...acc` spread throws "Spread syntax requires ...iterable not be
+        // null or undefined", crashing the whole response parse.
+        return acc;
     }
   }, []);
 };


### PR DESCRIPTION
## Summary

The Anthropic `responseParser` reduces over the response content blocks with a `switch` that handles only `text` and `tool_use`. There is no `default` case, so when Anthropic returns a block type the parser does not map — for example `redacted_thinking`, or a block type introduced in a future API version — the `reduce` callback falls through and returns `undefined`. On the next iteration `...acc` then throws:

```
TypeError: Spread syntax requires ...iterable not be null or undefined
```

which fails the entire response parse. The recently added `thinking` handling (#287) covers plain extended-thinking blocks, but `redacted_thinking` and any other unrecognized block still hit this path.

This adds a `default` case that skips unmapped blocks, so an unrecognized block type is ignored instead of crashing the parse.

## Changes

- `packages/agent-kit/src/adapters/anthropic.ts`: add `default: return acc;` to the `responseParser` switch, with a comment explaining the failure mode.
- `packages/agent-kit/src/adapters/anthropic.test.ts`: add regression tests for a `redacted_thinking` block followed by text, and for an unknown block type followed by `tool_use`.
- Changeset (patch).

## Notes

- Behavior for `text`, `tool_use`, and `thinking` blocks is unchanged.
- Skipping is the conservative choice for `redacted_thinking`: its contents are encrypted and the request parser already skips `reasoning`/thinking on outbound messages, so there is nothing to surface downstream. Representing it more richly can be a follow-up.

## Test plan

- [x] `vitest run src/adapters/anthropic.test.ts` — 7 passed (5 existing + 2 new).
- [x] `tsc --noEmit` clean.

Seen in production against Claude Sonnet 5, which emits `thinking`/`redacted_thinking` blocks; the crash reproduced on the first inference turn of every agent run until the block types were handled.

Made with [Cursor](https://cursor.com)