### PR TITLE
fix: preserve DeepSeek reasoning across tool calls

### DIFF
--- a/.changeset/deepseek-reasoning-roundtrip.md
+++ b/.changeset/deepseek-reasoning-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Preserve DeepSeek reasoning content across multi-turn tool calls without changing native OpenAI request history.

--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { responseParser, requestParser, isReasoningModel } from "./openai";
+import {
+  responseParser,
+  requestParser,
+  isDeepSeekModel,
+  isReasoningModel,
+} from "./openai";
 import type { Message, ReasoningMessage } from "../types";
 
 describe("openai responseParser", () => {
@@ -140,6 +145,10 @@ describe("openai requestParser", () => {
     options: { model: "gpt-4" },
   } as never;
 
+  const deepSeekModel = {
+    options: { model: "deepseek-v4-flash" },
+  } as never;
+
   test("should filter out reasoning messages from request", () => {
     const messages: Message[] = [
       { type: "text", role: "system", content: "You are helpful." },
@@ -152,6 +161,7 @@ describe("openai requestParser", () => {
     const outMessages = result.messages as Array<{
       role: string;
       content: string;
+      reasoning_content?: string;
     }>;
 
     expect(outMessages).toHaveLength(3);
@@ -159,6 +169,104 @@ describe("openai requestParser", () => {
     expect(outMessages[1]!.role).toBe("user");
     expect(outMessages[2]!.role).toBe("assistant");
     expect(outMessages[2]!.content).toBe("4");
+    expect(outMessages[2]!.reasoning_content).toBeUndefined();
+  });
+
+  test("should include reasoning_content in DeepSeek assistant text", () => {
+    const messages: Message[] = [
+      { type: "text", role: "user", content: "What is 2+2?" },
+      { type: "reasoning", role: "assistant", content: "Let me think..." },
+      { type: "text", role: "assistant", content: "4" },
+    ];
+
+    const result = requestParser(deepSeekModel, messages, [], "auto");
+    const outMessages = result.messages as Array<{
+      role: string;
+      content: string;
+      reasoning_content?: string;
+    }>;
+
+    expect(outMessages).toHaveLength(2);
+    expect(outMessages[1]).toEqual({
+      role: "assistant",
+      content: "4",
+      reasoning_content: "Let me think...",
+    });
+  });
+
+  test("should round-trip DeepSeek reasoning_content with a tool call", () => {
+    const response = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            reasoning_content: "I should fetch the data.",
+            tool_calls: [
+              {
+                id: "call_123",
+                type: "function",
+                function: {
+                  name: "get_data",
+                  arguments: '{"query":"test"}',
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+    const parsedResponse = responseParser(response as never);
+    const messages: Message[] = [
+      { type: "text", role: "user", content: "Get me data" },
+      ...parsedResponse,
+      {
+        type: "tool_result",
+        role: "tool_result",
+        tool: {
+          type: "tool",
+          id: "call_123",
+          name: "get_data",
+          input: { query: "test" },
+        },
+        content: "result",
+        stop_reason: "tool",
+      },
+    ];
+
+    const request = requestParser(deepSeekModel, messages, [], "auto");
+    const outMessages = request.messages as Array<{
+      role: string;
+      content: string | null;
+      reasoning_content?: string;
+      tool_calls?: unknown[];
+      tool_call_id?: string;
+    }>;
+
+    expect(outMessages).toHaveLength(3);
+    expect(outMessages[1]).toMatchObject({
+      role: "assistant",
+      content: null,
+      reasoning_content: "I should fetch the data.",
+    });
+    expect(outMessages[1]!.tool_calls).toHaveLength(1);
+    expect(outMessages[2]).toEqual({
+      role: "tool",
+      tool_call_id: "call_123",
+      content: "result",
+    });
+  });
+
+  test("should drop orphaned DeepSeek reasoning without an assistant message", () => {
+    const messages: Message[] = [
+      { type: "text", role: "user", content: "Hello" },
+      { type: "reasoning", role: "assistant", content: "Thinking..." },
+    ];
+
+    const result = requestParser(deepSeekModel, messages, [], "auto");
+
+    expect(result.messages).toEqual([{ role: "user", content: "Hello" }]);
   });
 
   test("should not set parallel_tool_calls for reasoning models", () => {
@@ -227,5 +335,20 @@ describe("isReasoningModel", () => {
   test("should be case insensitive", () => {
     expect(isReasoningModel("O3-Mini")).toBe(true);
     expect(isReasoningModel("GPT-5-PRO")).toBe(true);
+  });
+});
+
+describe("isDeepSeekModel", () => {
+  test("should detect DeepSeek model names", () => {
+    expect(isDeepSeekModel("deepseek-v4-flash")).toBe(true);
+    expect(isDeepSeekModel("deepseek-v4-pro")).toBe(true);
+    expect(isDeepSeekModel("provider/deepseek-reasoner")).toBe(true);
+    expect(isDeepSeekModel("DEEPSEEK-V4-FLASH")).toBe(true);
+  });
+
+  test("should not detect OpenAI models", () => {
+    expect(isDeepSeekModel("gpt-4o")).toBe(false);
+    expect(isDeepSeekModel("o3-mini")).toBe(false);
+    expect(isDeepSeekModel(undefined)).toBe(false);
   });
 });

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -26,19 +26,39 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
   tools,
   tool_choice = "auto"
 ) => {
+  // DeepSeek thinking models require reasoning_content from an assistant
+  // response to be sent back with the corresponding assistant message in
+  // subsequent tool-calling requests. Keep this provider-specific because
+  // reasoning messages for native OpenAI models are intentionally omitted.
+  const preserveReasoningContent = isDeepSeekModel(model.options.model);
+  let pendingReasoning: string | undefined;
+
   const request: AiAdapter.Input<OpenAi.AiModel> = {
     messages: messages
       .map((m: Message) => {
         switch (m.type) {
           case "reasoning":
+            if (preserveReasoningContent) {
+              pendingReasoning = m.content;
+            }
             return null;
-          case "text":
-            return {
+          case "text": {
+            const textMessage = {
               role: m.role,
               content: m.content,
             };
-          case "tool_call":
-            return {
+
+            if (m.role === "assistant" && pendingReasoning) {
+              Object.assign(textMessage, {
+                reasoning_content: pendingReasoning,
+              });
+              pendingReasoning = undefined;
+            }
+
+            return textMessage;
+          }
+          case "tool_call": {
+            const toolCallMessage = {
               role: "assistant",
               content: null,
               tool_calls: m.tools
@@ -52,6 +72,16 @@ export const requestParser: AgenticModel.RequestParser<OpenAi.AiModel> = (
                   }))
                 : undefined,
             };
+
+            if (pendingReasoning) {
+              Object.assign(toolCallMessage, {
+                reasoning_content: pendingReasoning,
+              });
+              pendingReasoning = undefined;
+            }
+
+            return toolCallMessage;
+          }
           case "tool_result":
             return {
               role: "tool",
@@ -224,6 +254,14 @@ export const isReasoningModel = (modelName: string | undefined): boolean => {
   // gpt reasoning variants: gpt-5.x-pro, gpt-5.x-codex
   if (/gpt-\d.*-(pro|codex)/.test(name)) return true;
   return false;
+};
+
+/**
+ * Detect DeepSeek models that use the OpenAI-compatible API but require
+ * provider-specific reasoning_content round-tripping for tool calls.
+ */
+export const isDeepSeekModel = (modelName: string | undefined): boolean => {
+  return modelName?.toLowerCase().includes("deepseek") ?? false;
 };
 
 const openAiStopReasonToStateStopReason: Record<string, string> = {


### PR DESCRIPTION
This preserves DeepSeek `reasoning_content` across multi-turn tool calls while keeping native OpenAI request history unchanged.

Issue #317 reports that AgentKit extracts DeepSeek reasoning from a response but drops it when reconstructing the next assistant message. DeepSeek's thinking-mode contract requires that reasoning to accompany the corresponding assistant text or tool call. This builds on #318 by @Jackson57279, with provider scoping so GPT and o-series requests do not receive a DeepSeek-specific field.

```text
Before
reasoning → dropped → assistant tool_call → tool_result

After (DeepSeek only)
reasoning → assistant { reasoning_content, tool_calls } → tool_result

Native OpenAI
reasoning → dropped → existing request shape remains unchanged
```

The request parser now temporarily associates a reasoning message with the next assistant text or tool-call message for DeepSeek model names. It clears the pending value after attachment and drops orphaned reasoning that has no corresponding assistant message.

The regression coverage exercises text responses, complete response-to-request tool-call round trips, orphaned reasoning, DeepSeek model detection, and unchanged GPT behavior. The full AgentKit suite passes (70 tests), along with TypeScript, ESLint, package build, and changeset validation. A live `deepseek-v4-flash` thinking-mode test also completed a two-request tool round trip successfully.

Closes #317.

## Changelog
- Fix DeepSeek reasoning history across multi-turn tool calls
