### PR TITLE
fix: safely recover malformed tool arguments

### DIFF
--- a/.changeset/safe-deepseek-tool-json.md
+++ b/.changeset/safe-deepseek-tool-json.md
@@ -1,0 +1,5 @@
+---
+"@inngest/agent-kit": patch
+---
+
+Safely recover raw control characters and invalid escapes in tool-call JSON, and validate arguments before tool execution.

--- a/packages/agent-kit/src/adapters/openai.test.ts
+++ b/packages/agent-kit/src/adapters/openai.test.ts
@@ -133,6 +133,261 @@ describe("openai responseParser", () => {
 
     expect(result[1]!.type).toBe("tool_call");
   });
+
+  test("should parse backtick-delimited tool arguments containing template literals", () => {
+    const source = [
+      "export const Greeting = ({ name }: { name: string }) => {",
+      "  const greeting = `Hello, ${name}`;",
+      "  return <div>{`Message: ${greeting}`}</div>;",
+      "};",
+    ].join("\n");
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_write",
+                type: "function",
+                function: {
+                  name: "write",
+                  arguments: `{"files":[{"path":"app.tsx","content":\`${source}\`}]}`,
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result[0]).toMatchObject({
+      type: "tool_call",
+      tools: [
+        {
+          input: {
+            files: [{ path: "app.tsx", content: source }],
+          },
+        },
+      ],
+    });
+  });
+
+  test("should parse multiple backtick-delimited tool arguments", () => {
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_write",
+                type: "function",
+                function: {
+                  name: "write",
+                  arguments:
+                    '{"files":[{"path":"a.ts","content":`export const a = 1;`},{"path":"b.ts","content":`export const b = `two`;`}]}',
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result[0]).toMatchObject({
+      type: "tool_call",
+      tools: [
+        {
+          input: {
+            files: [
+              { path: "a.ts", content: "export const a = 1;" },
+              { path: "b.ts", content: "export const b = `two`;" },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  test("should preserve raw control characters inside JSON strings", () => {
+    const content = "first line\n\tindented\u0000value\u001fend\r\n";
+    const argumentsText = `{"files":[{"path":"app.tsx","content":"${content}"}]}`;
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_write",
+                type: "function",
+                function: {
+                  name: "write",
+                  arguments: argumentsText,
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result[0]).toMatchObject({
+      type: "tool_call",
+      tools: [
+        {
+          input: {
+            files: [{ path: "app.tsx", content }],
+          },
+        },
+      ],
+    });
+  });
+
+  test("should not change valid JSON strings containing escaped controls", () => {
+    const argumentsText =
+      '{"files":[{"path":"app.tsx","content":"line one\\n\\tline two\\u0000"}]}';
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_write",
+                type: "function",
+                function: { name: "write", arguments: argumentsText },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result[0]).toMatchObject({
+      type: "tool_call",
+      tools: [
+        {
+          input: {
+            files: [{ path: "app.tsx", content: "line one\n\tline two\u0000" }],
+          },
+        },
+      ],
+    });
+  });
+
+  test("should preserve invalid JSON escapes as literal string content", () => {
+    const content = [
+      "const surname = 'Liam O\\'Brien';",
+      "const digits = /\\d+/g;",
+      "const hex = '\\x41';",
+    ].join("\n");
+    const argumentsText = `{"files":[{"path":"app.ts","content":"${content}"}]}`;
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_write",
+                type: "function",
+                function: { name: "write", arguments: argumentsText },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    const result = responseParser(input as never);
+    expect(result[0]).toMatchObject({
+      type: "tool_call",
+      tools: [
+        {
+          input: {
+            files: [{ path: "app.ts", content }],
+          },
+        },
+      ],
+    });
+  });
+
+  test("should reject ambiguous malformed JSON with sanitized diagnostics", () => {
+    const argumentsText = '{"command":"node -e "console.log(\\"unsafe\\")""}';
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_bash",
+                type: "function",
+                function: { name: "bash", arguments: argumentsText },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    expect(() => responseParser(input as never)).toThrow(
+      `Failed to parse tool arguments for bash (finish_reason: tool_calls, arguments_length: ${argumentsText.length})`
+    );
+    expect(() => responseParser(input as never)).toThrow(
+      "Invalid JSON separator"
+    );
+
+    try {
+      responseParser(input as never);
+    } catch (error) {
+      expect(String(error)).not.toContain("console.log");
+    }
+  });
+
+  test("should reject an escaped raw control character as ambiguous", () => {
+    const argumentsText = '{"command":"echo \\\nnext"}';
+    const input = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_bash",
+                type: "function",
+                function: { name: "bash", arguments: argumentsText },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+
+    expect(() => responseParser(input as never)).toThrow(
+      "Failed to parse tool arguments for bash"
+    );
+  });
 });
 
 describe("openai requestParser", () => {

--- a/packages/agent-kit/src/adapters/openai.ts
+++ b/packages/agent-kit/src/adapters/openai.ts
@@ -164,13 +164,17 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
         ...base,
         type: "tool_call",
         tools: message.tool_calls.map((tool) => {
+          const argumentsText = tool.function.arguments || "{}";
           return {
             type: "tool",
             id: tool.id,
             name: tool.function.name,
             function: tool.function.name, // Duplicate for backward compatibility
             // Use safe parser to handle OpenAI's JSON quirks (like backticks in strings)
-            input: safeParseOpenAIJson(tool.function.arguments || "{}"),
+            input: safeParseOpenAIJson(argumentsText, {
+              toolName: tool.function.name,
+              finishReason: finish_reason,
+            }),
           } as ToolMessage;
         }),
       } as ToolCallMessage);
@@ -189,27 +193,275 @@ export const responseParser: AgenticModel.ResponseParser<OpenAi.AiModel> = (
  * "{\n  \"files\": [\n    {\n      \"filename\": \"fibo.ts\",\n      \"content\": `\nfunction fibonacci(n: number): number {\n  if (n < 2) {\n    return n;\n  } else {\n    return fibonacci(n - 1) + fibonacci(n - 2);\n  }\n}\n\nexport default fibonacci;\n`\n    }\n  ]\n}"
  * ```
  */
-const safeParseOpenAIJson = (str: string): unknown => {
+const safeParseOpenAIJson = (
+  str: string,
+  diagnostics: {
+    toolName: string;
+    finishReason: string | null | undefined;
+  }
+): unknown => {
   // Remove any leading/trailing quotes if present
   const trimmed = str.replace(/^["']|["']$/g, "");
 
   try {
     // First try direct JSON parse
     return JSON.parse(trimmed);
-  } catch {
+  } catch (directParseError) {
+    const withEscapedControlCharacters =
+      escapeUnescapedControlCharactersInJsonStrings(trimmed);
+    const withSafeStringRepairs = escapeInvalidJsonStringBackslashes(
+      withEscapedControlCharacters
+    );
+
     try {
-      // Replace backtick strings with regular JSON strings
-      // Match content between backticks, preserving newlines
-      const withQuotes = trimmed.replace(/`([\s\S]*?)`/g, (_, content) =>
-        JSON.stringify(content)
-      );
-      return JSON.parse(withQuotes);
-    } catch (e) {
+      // Generated source sometimes contains literal control characters inside
+      // a JSON string. Escaping only those characters preserves the decoded
+      // string value without guessing about quotes or JSON structure.
+      if (withSafeStringRepairs !== trimmed) {
+        try {
+          return JSON.parse(withSafeStringRepairs);
+        } catch {
+          // It may also contain backtick-delimited strings; handle those below.
+        }
+      }
+
+      return parseJsonWithBacktickStrings(withSafeStringRepairs);
+    } catch (fallbackError) {
+      const diagnosticError =
+        fallbackError instanceof SyntaxError ||
+        !(directParseError instanceof SyntaxError)
+          ? fallbackError
+          : directParseError;
       throw new Error(
-        `Failed to parse JSON with backticks: ${stringifyError(e)}`
+        `Failed to parse tool arguments for ${diagnostics.toolName} ` +
+          `(finish_reason: ${diagnostics.finishReason ?? "unknown"}, ` +
+          `arguments_length: ${str.length}): ${sanitizeJsonParseError(diagnosticError)}`
       );
     }
   }
+};
+
+const sanitizeJsonParseError = (error: unknown): string => {
+  if (!(error instanceof SyntaxError)) {
+    return stringifyError(error);
+  }
+
+  const message = error.message;
+  const position = message.match(/\bposition\s+(\d+)\b/i)?.[1];
+  const location = position ? ` at position ${position}` : "";
+
+  if (/control character/i.test(message)) {
+    return `Bad control character in JSON string${location}`;
+  }
+  if (/unexpected end|unterminated string/i.test(message)) {
+    return `Unexpected end of JSON input${location}`;
+  }
+  if (/property name/i.test(message)) {
+    return `Invalid JSON property name${location}`;
+  }
+  if (/after property value|expected.*[,}\]]/i.test(message)) {
+    return `Invalid JSON separator${location}`;
+  }
+
+  return `Invalid JSON${location}`;
+};
+
+/**
+ * Escape raw JSON control characters only while inside a double-quoted string.
+ * A control character following an unmatched backslash is left untouched so
+ * ambiguous input continues to fail instead of being guessed at.
+ */
+const escapeUnescapedControlCharactersInJsonStrings = (
+  input: string
+): string => {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+
+  for (const character of input) {
+    const codePoint = character.charCodeAt(0);
+    if (inString && !escaped && codePoint <= 0x1f) {
+      output += escapeJsonControlCharacter(character, codePoint);
+      continue;
+    }
+
+    output += character;
+
+    if (escaped) {
+      escaped = false;
+    } else if (inString && character === "\\") {
+      escaped = true;
+    } else if (character === '"') {
+      inString = !inString;
+    }
+  }
+
+  return output;
+};
+
+const escapeJsonControlCharacter = (
+  character: string,
+  codePoint: number
+): string => {
+  switch (character) {
+    case "\b":
+      return "\\b";
+    case "\t":
+      return "\\t";
+    case "\n":
+      return "\\n";
+    case "\f":
+      return "\\f";
+    case "\r":
+      return "\\r";
+    default:
+      return `\\u${codePoint.toString(16).padStart(4, "0")}`;
+  }
+};
+
+/**
+ * Preserve invalid JSON escape sequences as literal string content by escaping
+ * their backslash. For example, `\d` becomes `\\d` in the JSON source and
+ * decodes back to the original two characters. Valid JSON escapes and a
+ * backslash followed by a raw control character are left unchanged.
+ */
+const escapeInvalidJsonStringBackslashes = (input: string): string => {
+  let output = "";
+  let inString = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const character = input[i]!;
+    if (character === '"') {
+      inString = !inString;
+      output += character;
+      continue;
+    }
+
+    if (!inString || character !== "\\") {
+      output += character;
+      continue;
+    }
+
+    const nextCharacter = input[i + 1];
+    if (nextCharacter === undefined || nextCharacter.charCodeAt(0) <= 0x1f) {
+      output += character;
+      continue;
+    }
+
+    if ('"\\/bfnrt'.includes(nextCharacter)) {
+      output += character + nextCharacter;
+      i++;
+      continue;
+    }
+
+    if (
+      nextCharacter === "u" &&
+      /^[0-9a-fA-F]{4}$/.test(input.slice(i + 2, i + 6))
+    ) {
+      output += input.slice(i, i + 6);
+      i += 5;
+      continue;
+    }
+
+    output += "\\\\";
+  }
+
+  return output;
+};
+
+/**
+ * Parses JSON-like tool arguments whose string values are delimited with
+ * backticks. Generated source code can itself contain template literals, so a
+ * regular expression cannot reliably identify the closing delimiter. Try only
+ * structurally plausible delimiters and accept a repair once the entire value
+ * parses as JSON.
+ */
+const parseJsonWithBacktickStrings = (input: string): unknown => {
+  const maxAttempts = 1_000;
+  let attempts = 0;
+
+  const parse = (value: string, searchFrom = 0): unknown => {
+    if (++attempts > maxAttempts) {
+      throw new Error("Too many possible backtick delimiters");
+    }
+
+    const openingIndex = findBacktickOutsideJsonString(value, searchFrom);
+    if (openingIndex === -1) {
+      return JSON.parse(value);
+    }
+
+    let lastError: unknown;
+    for (
+      let closingIndex = openingIndex + 1;
+      closingIndex < value.length;
+      closingIndex++
+    ) {
+      if (
+        value[closingIndex] !== "`" ||
+        isEscaped(value, closingIndex) ||
+        !isPossibleBacktickDelimiter(value, closingIndex)
+      ) {
+        continue;
+      }
+
+      const content = value.slice(openingIndex + 1, closingIndex);
+      const quotedContent = JSON.stringify(content);
+      const repaired =
+        value.slice(0, openingIndex) +
+        quotedContent +
+        value.slice(closingIndex + 1);
+
+      try {
+        return parse(repaired, openingIndex + quotedContent.length);
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    if (lastError instanceof Error) {
+      throw lastError;
+    }
+    throw new Error(
+      lastError === undefined
+        ? "Unterminated backtick-delimited string"
+        : stringifyError(lastError)
+    );
+  };
+
+  return parse(input);
+};
+
+const findBacktickOutsideJsonString = (
+  input: string,
+  searchFrom: number
+): number => {
+  let inString = false;
+
+  for (let i = searchFrom; i < input.length; i++) {
+    if (input[i] === '"' && !isEscaped(input, i)) {
+      inString = !inString;
+      continue;
+    }
+
+    if (!inString && input[i] === "`" && !isEscaped(input, i)) {
+      return i;
+    }
+  }
+
+  return -1;
+};
+
+const isEscaped = (input: string, index: number): boolean => {
+  let precedingBackslashes = 0;
+  for (let i = index - 1; i >= 0 && input[i] === "\\"; i--) {
+    precedingBackslashes++;
+  }
+  return precedingBackslashes % 2 === 1;
+};
+
+const isPossibleBacktickDelimiter = (input: string, index: number): boolean => {
+  const nextToken = input.slice(index + 1).match(/^\s*(.)/)?.[1];
+  return nextToken === undefined || [",", "}", "]"].includes(nextToken);
 };
 
 /**

--- a/packages/agent-kit/src/agent.tools.test.ts
+++ b/packages/agent-kit/src/agent.tools.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+import { createAgent } from "./agent";
+import { openai } from "./models";
+import { createTool } from "./tool";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Agent tool invocation", () => {
+  test("validates model input before executing a tool handler", async () => {
+    const handler = vi.fn(() => ({ ok: true }));
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "call_write",
+                    type: "function",
+                    function: {
+                      name: "write",
+                      arguments: '{"files":"not-an-array"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+        })
+      )
+    );
+
+    const agent = createAgent({
+      name: "test-agent",
+      system: "Use the write tool.",
+      model: openai({ model: "gpt-4o", apiKey: "test-key" }),
+      tools: [
+        createTool({
+          name: "write",
+          parameters: z.object({
+            files: z.array(z.object({ path: z.string(), content: z.string() })),
+          }),
+          handler,
+        }),
+      ],
+    });
+
+    const result = await agent.run("Write a file");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]?.content).toHaveProperty("error");
+  });
+});

--- a/packages/agent-kit/src/agent.ts
+++ b/packages/agent-kit/src/agent.ts
@@ -731,13 +731,18 @@ export class Agent<T extends StateData> {
           | { data: unknown }
           | { error: ReturnType<typeof errors.serializeError> };
 
-        const result: ToolHandlerResult = await Promise.resolve(
-          found.handler(tool.input, {
-            agent: this,
-            network,
-            step: step as GetStepTools<Inngest.Any>,
+        const result: ToolHandlerResult = await Promise.resolve()
+          .then(async () => {
+            const input = found.parameters
+              ? await found.parameters.parseAsync(tool.input)
+              : tool.input;
+
+            return found.handler(input, {
+              agent: this,
+              network,
+              step: step as GetStepTools<Inngest.Any>,
+            });
           })
-        )
           .then((r) => {
             return {
               data:


### PR DESCRIPTION
Safely recovers malformed tool-call JSON string content and validates parsed arguments before any tool handler executes.

DeepSeek can return HTTP 200 tool calls whose `function.arguments` contain raw control characters, invalid JSON escapes from generated source code, or ambiguous structural errors even when strict tool calling uses the beta endpoint. The old parser either rejected safely recoverable string content or used a regular expression that misidentified nested JavaScript template literals.

The parser now follows a deliberately narrow path:

```
direct JSON.parse
  ├── valid → return unchanged
  └── invalid → preserve raw controls / invalid escapes
                  ↓
             structural backtick parsing
                  ├── valid → Zod parseAsync → handler
                  └── ambiguous → sanitized error, no handler
```

Raw U+0000–U+001F characters are encoded so the decoded string value is unchanged. Invalid JSON escapes such as `\'` or `\d` have only their backslash escaped, preserving the exact original characters. Unescaped quotes, missing separators, and malformed structure are not guessed at. Errors include only tool name, finish reason, argument length, category, and position.

This also closes a safety gap where Zod schemas were converted for provider requests but were not applied at runtime before local, Inngest, or MCP tool handlers.

Live beta-endpoint stress testing produced two malformed responses among six HTTP 200 `tool_calls` responses. The invalid-escape response is recovered byte-semantically by this patch; the ambiguous unescaped-quote response remains an error as intended.

Validation: 73/73 tests including both MCP transports, TypeScript, ESLint, package build, a full 36,341-character captured invalid-escape fixture, and a fresh 45,352-character real DeepSeek call after reinstall and restart.

Partially addresses #329.

## Changelog
- Safely recover generated source code from malformed tool-call JSON while rejecting ambiguous repairs
- Validate tool arguments before executing handlers